### PR TITLE
feat: ASCII logo + wordmark banner on bare CLI and daemon start

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         },
         "hooks": {
             "init": [
-                "./dist/cli/hooks/init/version-hook"
+                "./dist/cli/hooks/init/version-hook",
+                "./dist/cli/hooks/init/banner-hook"
             ],
             "prerun": [
                 "./dist/cli/hooks/prerun/parse-dynamic-flags-hook"

--- a/src/cli/ascii-banner.ts
+++ b/src/cli/ascii-banner.ts
@@ -1,0 +1,94 @@
+// ASCII banner, edited as two parallel grids.
+//
+// SHAPE holds the raw glyphs (braille art + figlet text). Leave these alone
+// unless you want to change the art itself.
+//
+// COLORS is the paint map. Each character corresponds 1:1 to the character
+// at the same position in SHAPE:
+//   B = blue   (#1a4fd0) — the sphere
+//   S = silver (#e5e7eb) — the rings and the "Bitsocial" text
+//   . = no color (pass the glyph through as-is; use this for spaces)
+//
+// To retouch the art, find a glyph in SHAPE, then flip the character at the
+// same column in the matching COLORS row. A common case: a ring cell came out
+// blue because the sphere mask had more dots there — change its 'B' to 'S'.
+//
+// Both grids MUST have the same number of rows. Each row in COLORS must be at
+// least as wide as the corresponding SHAPE row (extra chars are ignored).
+// Palette sourced from bitsocialnet/bitsocial-web/about/tailwind.config.ts.
+
+const SHAPE = [
+    "                ⢀⣴⣿⣿⣦⡀                                                                                       ",
+    "                ⣾⣿⠁⠈⣿⣷⡀                                                                                      ",
+    "               ⢸⣿⡇  ⢸⣿⣇                                                                                      ",
+    "             ⢀⣀⣼⣿⣷⣶⣶⣶⣿⣿⣄⡀                                                                                    ",
+    "          ⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣤⡀                                                                                 ",
+    "         ⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦               888888b.   d8b 888                               d8b          888",
+    "       ⢀⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀             888  \"88b  Y8P 888                               Y8P          888",
+    "  ⣀⣤⣤⣶⣶⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣶⣶⣦⣤⣀        888  .88P      888                                            888",
+    "⣰⣿⡿⠛⠉⠉ ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ ⠉⠉⠛⠟⣿⣦      8888888K.  888 888888 .d8888b   .d88b.   .d8888b 888  8888b.  888",
+    "⠻⣷⣦⣤⣀⣀ ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ ⢀⣀⣀⣴⣿⠟      888  \"Y88b 888 888    88K      d88\"\"88b d88P\"    888     \"88b 888",
+    "  ⠉⠛⠻⠿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠿⠟⠛⠉        888    888 888 888    \"Y8888b. 888  888 888      888 .d888888 888",
+    "       ⠈⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿              888   d88P 888 Y88b.       X88 Y88..88P Y88b.    888 888  888 888",
+    "         ⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟               8888888P\"  888  \"Y888  88888P'  \"Y88P\"   \"Y8888P 888 \"Y888888 888",
+    "          ⠈⠻⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⠁                                                                                 ",
+    "             ⠉⠛⢿⣿⣿⣿⣿⣿⣿⣿⠛⠉                                                                                    ",
+    "                ⢸⣿⡆  ⣿⡿                                                                                      ",
+    "                ⠈⢿⣷⡀⣸⣿⠃                                                                                       ",
+    "                 ⠈⠿⣿⡿⠃                                                                                        "
+];
+
+const COLORS = [
+    "................SSSSSS.......................................................................................",
+    "................SSSSSSS......................................................................................",
+    "...............SSSSSSSS......................................................................................",
+    ".............BBBBBBBBSSBB....................................................................................",
+    "..........BBBBBBBBBBBSSBBBBB.................................................................................",
+    ".........BBBBBBBBBBBBSSBBBBBB...............SSSSSSSS...SSS.SSS...............................SSS..........SSS",
+    ".......BBBBBBBBBBBBBBSSBBBBBBBB.............SSS..SSSS..SSS.SSS...............................SSS..........SSS",
+    "..SSSSSBBBBBBBBBBBBBBSSBBBBBBBBSSSSSSS......SSS..SSSS......SSS............................................SSS",
+    "SSSSSS.BBBBBBBBBBBBBBSSBBBBBBBBSSSSSSS......SSSSSSSSS..SSS.SSSSSS.SSSSSSS...SSSSSS...SSSSSSS.SSS..SSSSSS..SSS",
+    "SSSSSS.BBBBBBBBBBBBBBSSBBBBBBBBSSSSSSS......SSS..SSSSS.SSS.SSS....SSS......SSSSSSSS.SSSSS....SSS.....SSSS.SSS",
+    "..SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS......SSS....SSS.SSS.SSS....SSSSSSSS.SSS..SSS.SSS......SSS.SSSSSSSS.SSS",
+    ".......BBBBBBBBBBBBBBSSBBBBBBBBBBBBBBB......SSS...SSSS.SSS.SSSSS.......SSS.SSSSSSSS.SSSSS....SSS.SSS..SSS.SSS",
+    ".........BBBBBBBBBBBBSSBBBBBBBBB............SSSSSSSSS..SSS..SSSSS..SSSSSSS..SSSSSS...SSSSSSS.SSS.SSSSSSSS.SSS",
+    "..........BBBBBBBBBBBSSBBBBBBB...............................................................................",
+    ".............BBBBBBBBSSBBBB..................................................................................",
+    "...............SSSSSSSSS.....................................................................................",
+    "...............SSSSSSSS......................................................................................",
+    "................SSSSSS......................................................................................."
+];
+
+const BLUE = "\x1b[38;2;26;79;208m";
+const SILVER = "\x1b[38;2;229;231;235m";
+const RESET = "\x1b[0m";
+
+function paint(shape: string, colors: string): string {
+    let out = "";
+    let current = ".";
+    for (let i = 0; i < shape.length; i++) {
+        const glyph = shape[i]!;
+        const want = colors[i] ?? ".";
+        if (want !== current) {
+            if (current !== ".") out += RESET;
+            if (want === "B") out += BLUE;
+            else if (want === "S") out += SILVER;
+            current = want;
+        }
+        out += glyph;
+    }
+    if (current !== ".") out += RESET;
+    return out;
+}
+
+function supportsColor(): boolean {
+    if (process.env["NO_COLOR"]) return false;
+    if (process.env["FORCE_COLOR"]) return true;
+    return Boolean(process.stdout.isTTY);
+}
+
+export function printBanner(): void {
+    const useColor = supportsColor();
+    const lines = SHAPE.map((row, i) => (useColor ? paint(row, COLORS[i] ?? "") : row));
+    process.stdout.write(lines.join("\n") + "\n\n");
+}

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -15,6 +15,7 @@ import {
 } from "../../util.js";
 import type { PKCLoggerType } from "../../util.js";
 import { startDaemonServer } from "../../webui/daemon-server.js";
+import { printBanner } from "../ascii-banner.js";
 import { loadChallengesIntoPKC } from "../../challenge-packages/challenge-utils.js";
 import { migrateDataDirectory } from "../../common-utils/data-migration.js";
 import { createBsoResolvers } from "../../common-utils/resolvers.js";
@@ -186,6 +187,7 @@ export default class Daemon extends Command {
     }
 
     async run() {
+        printBanner();
         // Non-blocking update check — fire-and-forget, won't delay startup
         import("../../update/npm-registry.js")
             .then(({ fetchLatestVersion }) =>

--- a/src/cli/hooks/init/banner-hook.ts
+++ b/src/cli/hooks/init/banner-hook.ts
@@ -1,0 +1,19 @@
+import { Hook } from "@oclif/core";
+import { printBanner } from "../../ascii-banner.js";
+
+const hook: Hook<"init"> = async function (opts) {
+    // Skip when --version is being handled by version-hook
+    if (process.argv.includes("--version")) return;
+
+    // Show banner on bare `bitsocial` invocation (no command, no help flag).
+    // oclif sets opts.id to undefined when no command is matched; argv length > 2
+    // means the user passed flags/args and expects normal command output.
+    const bareInvocation = process.argv.length <= 2;
+    const helpInvocation = !opts.id && (process.argv.includes("--help") || process.argv.includes("-h") || process.argv.includes("help"));
+
+    if (bareInvocation || helpInvocation) {
+        printBanner();
+    }
+};
+
+export default hook;


### PR DESCRIPTION
## Summary

- Shows the Bitsocial sphere-with-rings logo (braille art) next to a "Bitsocial" figlet wordmark when running bare `bitsocial`, `bitsocial --help`/`help`, and on `bitsocial daemon` startup.
- Palette matches brand tokens from `bitsocialnet/bitsocial-web/about/tailwind.config.ts` — `blue-core` (#1a4fd0) for the sphere, `silver-bright` (#e5e7eb) for the rings and wordmark. 24-bit ANSI truecolor, respects `NO_COLOR` and `FORCE_COLOR`.
- The art is stored as two parallel grids (`SHAPE` + `COLORS`) in [src/cli/ascii-banner.ts](../blob/claude/flamboyant-knuth-523fd9/src/cli/ascii-banner.ts) so individual glyph colors can be retouched by flipping a single character in the paint map.

Refs #19

## Test plan

- [ ] `FORCE_COLOR=1 ./bin/run` — banner renders with blue sphere + silver rings + silver wordmark
- [ ] `NO_COLOR=1 ./bin/run` — banner renders without ANSI escapes
- [ ] `./bin/run --help` — banner appears above help text
- [ ] `./bin/run daemon` — banner appears before daemon boot output
- [ ] `./bin/run <any real command>` — banner is NOT shown
- [ ] `npm run test:cli` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds terminal-only banner output gated to bare/help invocations and daemon startup, with basic color detection; no changes to core command logic or data handling.
> 
> **Overview**
> Adds a branded ASCII logo + wordmark banner to the CLI.
> 
> Introduces `printBanner()` (with optional truecolor output honoring `NO_COLOR`/`FORCE_COLOR` and TTY detection) and wires it to display on bare `bitsocial` / `--help` invocations via a new `init` hook, and at the start of `bitsocial daemon`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be9873b5fbf31f535468cf03cb38f6a0068fc6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ASCII banner now displays during CLI startup and help commands with automatic color support based on terminal capabilities. Use `NO_COLOR` environment variable to disable colors or `FORCE_COLOR` to enable them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->