### PR TITLE
chore: upgrade @pkcprotocol/pkc-js from 0.0.16 to 0.0.17

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -17,10 +17,19 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Generate release token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -33,8 +42,8 @@ jobs:
 
       - name: Set up Git commit author
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --local user.name "bitsocial-release-bot[bot]"
+          git config --local user.email "3419549+bitsocial-release-bot[bot]@users.noreply.github.com"
 
       - name: Get current version
         id: before
@@ -42,7 +51,7 @@ jobs:
 
       - name: Create Github Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: npm run release -- --ci
 
       - name: Check if released

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,15 @@ jobs:
       - run: npm run build
       - run: npx oclif manifest
 
+      - name: Verify global install from pack
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TARBALL=$(npm pack)
+          npm install -g "./$TARBALL"
+          bitsocial --version
+
       # disable hosts we shouldn't use (Linux only)
       - name: Block unwanted hosts
         if: matrix.os == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.3
 
 ## `bitsocial logs`
 
-View the latest BitSocial daemon log file. By default dumps the full log and exits. Use --follow to stream new output in real-time (like tail -f).
+View the latest Bitsocial daemon log file. By default dumps the full log and exits. Use --follow to stream new output in real-time (like tail -f).
 
 ```
 USAGE
@@ -684,7 +684,7 @@ FLAGS
                          42m, 2h, 1d)
 
 DESCRIPTION
-  View the latest BitSocial daemon log file. By default dumps the full log and exits. Use --follow to stream new output
+  View the latest Bitsocial daemon log file. By default dumps the full log and exits. Use --follow to stream new output
   in real-time (like tail -f).
 
 EXAMPLES

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bitsocial is p2p and decentralized social media protocol built completely with I
 
 ## Install
 
-Requires [Node.js 22](https://nodejs.org/) or later.
+Requires Node.js 22 or later. We recommend using [nvm](https://github.com/nvm-sh/nvm) to install and manage Node.js versions.
 
 ```sh-session
 npm install -g @bitsocial/bitsocial-cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-    "name": "bitsocial-cli",
+    "name": "@bitsocial/bitsocial-cli",
     "version": "0.19.42",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "bitsocial-cli",
+            "name": "@bitsocial/bitsocial-cli",
             "version": "0.19.42",
+            "hasInstallScript": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@bitsocial/bso-resolver": "0.0.4",
@@ -15,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.16",
+                "@pkcprotocol/pkc-js": "0.0.17",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -4551,88 +4552,6 @@
                 "uint8arrays": "^5.1.0"
             }
         },
-        "node_modules/@libp2p/peer-id-factory": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.2.4.tgz",
-            "integrity": "sha512-NDQ/qIWpcAG/6xQjyut6xCkrYYAoCaI/33Z+7yzo5qFODwLfNonLzSTasnA6jhuvHn33aHnD1qhdpFkmstxtNQ==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@libp2p/crypto": "^4.1.9",
-                "@libp2p/interface": "^1.7.0",
-                "@libp2p/peer-id": "^4.2.4",
-                "protons-runtime": "^5.4.0",
-                "uint8arraylist": "^2.4.8",
-                "uint8arrays": "^5.1.0"
-            }
-        },
-        "node_modules/@libp2p/peer-id-factory/node_modules/@libp2p/crypto": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.9.tgz",
-            "integrity": "sha512-8Cf2VKh0uC/rQLvTLSloIOMqUvf4jsSTHXgjWQRf47lDNJlNNI0wSv2S6gakT72GZsRV/jCjYwKPqRlsa5S0iA==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@libp2p/interface": "^1.7.0",
-                "@noble/curves": "^1.4.0",
-                "@noble/hashes": "^1.4.0",
-                "asn1js": "^3.0.5",
-                "multiformats": "^13.1.0",
-                "protons-runtime": "^5.4.0",
-                "uint8arraylist": "^2.4.8",
-                "uint8arrays": "^5.1.0"
-            }
-        },
-        "node_modules/@libp2p/peer-id-factory/node_modules/@libp2p/interface": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.7.0.tgz",
-            "integrity": "sha512-/zFyaIaIGW0aihhsH7/93vQdpWInUzFocxF11RO/029Y6h0SVjs24HHbils+DqaFDTqN+L7oNlBx2rM2MnmTjA==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@multiformats/multiaddr": "^12.2.3",
-                "it-pushable": "^3.2.3",
-                "it-stream-types": "^2.0.1",
-                "multiformats": "^13.1.0",
-                "progress-events": "^1.0.0",
-                "uint8arraylist": "^2.4.8"
-            }
-        },
-        "node_modules/@libp2p/peer-id-factory/node_modules/@libp2p/peer-id": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.2.4.tgz",
-            "integrity": "sha512-mvvsVxt4HkF14BrTNKbqr14VObW+KBJBWu1Oe6BFCoDttGMQLaI+PdduE1r6Tquntv5IONBqoITgD7ow5dQ+vQ==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@libp2p/interface": "^1.7.0",
-                "multiformats": "^13.1.0",
-                "uint8arrays": "^5.1.0"
-            }
-        },
-        "node_modules/@libp2p/peer-id-factory/node_modules/@multiformats/multiaddr": {
-            "version": "12.5.1",
-            "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
-            "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@chainsafe/is-ip": "^2.0.1",
-                "@chainsafe/netmask": "^2.0.0",
-                "@multiformats/dns": "^1.0.3",
-                "abort-error": "^1.0.1",
-                "multiformats": "^13.0.0",
-                "uint8-varint": "^2.0.1",
-                "uint8arrays": "^5.0.0"
-            }
-        },
-        "node_modules/@libp2p/peer-id-factory/node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/@libp2p/peer-record": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-9.0.5.tgz",
@@ -5216,18 +5135,6 @@
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
-        },
-        "node_modules/@noble/secp256k1": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz",
-            "integrity": "sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -5878,9 +5785,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.16",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.16.tgz",
-            "integrity": "sha512-SzKVR8zbhi7y0sauZEdVJGz1SgLEqF6ec0nN47llpCc0tztIUVr1KdAWu8b42856zuwR2pS0UoCPaVLRqyPN6Q==",
+            "version": "0.0.17",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.17.tgz",
+            "integrity": "sha512-vyfcCaqgF/ddbqmJntrWvyNCz8++W/1sKjlj30od/2hNutXNJOIZ0RjQKddQ6lau1NlKCyZ58aLgKCBl5eiQVg==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",
@@ -5894,12 +5801,12 @@
                 "@libp2p/identify": "4.0.10",
                 "@libp2p/interfaces": "3.3.2",
                 "@libp2p/peer-id": "6.0.4",
-                "@libp2p/peer-id-factory": "4.2.4",
                 "@libp2p/websockets": "10.1.3",
-                "@pkcprotocol/pkc-logger": "github:pkcprotocol/pkc-logger#cb494fbaf332ed5b2cfd9d9d0f90ca7fd0058b4a",
-                "@pkcprotocol/proper-lock-file": "git+https://github.com/pkcprotocol/node-proper-lockfile.git#30564d7e0bd06d145c88a16896c779e97503a735",
+                "@noble/ed25519": "^1.7.5",
+                "@pkcprotocol/pkc-logger": "0.1.0",
+                "@pkcprotocol/proper-lock-file": "4.2.1",
                 "assert": "2.1.0",
-                "better-sqlite3": "12.6.2",
+                "better-sqlite3": "12.9.0",
                 "blockstore-core": "6.1.2",
                 "blockstore-fs": "3.0.2",
                 "blockstore-idb": "3.0.1",
@@ -5921,11 +5828,10 @@
                 "open-graph-scraper": "6.11.0",
                 "p-limit": "7.3.0",
                 "p-timeout": "7.0.1",
-                "peer-id": "0.16.0",
                 "probe-image-size": "7.2.3",
                 "remeda": "1.57.0",
                 "retry": "0.13.1",
-                "rpc-websockets": "9.3.1",
+                "rpc-websockets": "9.3.8",
                 "safe-stable-stringify": "2.4.3",
                 "sha1-uint8array": "0.10.7",
                 "tcp-port-used": "1.0.2",
@@ -5940,12 +5846,25 @@
                 "node": ">=20.18.0"
             }
         },
+        "node_modules/@pkcprotocol/pkc-js/node_modules/better-sqlite3": {
+            "version": "12.9.0",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+            "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
+            },
+            "engines": {
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+            }
+        },
         "node_modules/@pkcprotocol/pkc-logger": {
-            "name": "@pkc/pkc-logger",
-            "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/pkcprotocol/pkc-logger.git#cb494fbaf332ed5b2cfd9d9d0f90ca7fd0058b4a",
-            "integrity": "sha512-oknwMz+yyzS0DpOBZNUJvpoVR/u1ivHKjA3m0cR1oX73g59nqiG6agxfY1cNhodVtZeWh1N9ABe3FCE2l3spwQ==",
-            "license": "GPL-2.0",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-logger/-/pkc-logger-0.1.0.tgz",
+            "integrity": "sha512-C9qh1q0pbbRWGt6yh3AgmblYYpxnqim/eUjPE4ILktKPJfcadsYXULDFEts+mXvo9zsN2V3yym6i4zHzezAs3w==",
+            "license": "GPL-3.0-or-later",
             "dependencies": {
                 "debug": "4.4.3"
             },
@@ -5954,10 +5873,9 @@
             }
         },
         "node_modules/@pkcprotocol/proper-lock-file": {
-            "name": "@pkc/proper-lock-file",
-            "version": "4.1.2",
-            "resolved": "git+ssh://git@github.com/pkcprotocol/node-proper-lockfile.git#30564d7e0bd06d145c88a16896c779e97503a735",
-            "integrity": "sha512-c2pLHlOjz7UxtnNaLOPrpz5g/dXMrQLzcsW3jfos4uq7qKF/2GXS4Z6MBas/FIZXJ0YmB+Pu3HiDUfmwzjowBQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/proper-lock-file/-/proper-lock-file-4.2.1.tgz",
+            "integrity": "sha512-ctaXE7uksJq4FH6qcwHZqqco003tj1lYsrTlpWwoddVTpcTBmW+1uw0ISeR+aXdAZY9c4Xm93FP04k/5DOyZzg==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "4.2.11",
@@ -7684,9 +7602,9 @@
             "license": "MIT"
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-            "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+            "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -8150,9 +8068,9 @@
             "license": "MIT"
         },
         "node_modules/@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
             "license": "MIT"
         },
         "node_modules/@types/wrap-ansi": {
@@ -10528,12 +10446,6 @@
             "dependencies": {
                 "consola": "^3.2.3"
             }
-        },
-        "node_modules/class-is": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-            "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
-            "license": "MIT"
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
@@ -18397,19 +18309,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
-        "node_modules/iso-random-stream": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-            "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-            "license": "MIT",
-            "dependencies": {
-                "events": "^3.3.0",
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/iso-url": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
@@ -19431,40 +19330,6 @@
                 "progress-events": "^1.0.1",
                 "race-signal": "^2.0.0",
                 "uint8arrays": "^5.1.0"
-            }
-        },
-        "node_modules/libp2p-crypto": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.21.2.tgz",
-            "integrity": "sha512-EXFrhSpiHtJ+/L8xXDvQNK5VjUMG51u878jzZcaT5XhuN/zFg6PWJFnl/qB2Y2j7eMWnvCRP7Kp+ua2H36cG4g==",
-            "license": "MIT",
-            "dependencies": {
-                "@noble/ed25519": "^1.5.1",
-                "@noble/secp256k1": "^1.3.0",
-                "err-code": "^3.0.1",
-                "iso-random-stream": "^2.0.0",
-                "multiformats": "^9.4.5",
-                "node-forge": "^1.2.1",
-                "protobufjs": "^6.11.2",
-                "uint8arrays": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/libp2p-crypto/node_modules/multiformats": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-            "license": "(Apache-2.0 AND MIT)"
-        },
-        "node_modules/libp2p-crypto/node_modules/uint8arrays": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-            "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-            "license": "MIT",
-            "dependencies": {
-                "multiformats": "^9.4.2"
             }
         },
         "node_modules/lie": {
@@ -22711,37 +22576,6 @@
                 "through2": "^2.0.3"
             }
         },
-        "node_modules/peer-id": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.16.0.tgz",
-            "integrity": "sha512-EmL7FurFUduU9m1PS9cfJ5TAuCvxKQ7DKpfx3Yj6IKWyBRtosriFuOag/l3ni/dtPgPLwiA4R9IvpL7hsDLJuQ==",
-            "license": "MIT",
-            "dependencies": {
-                "class-is": "^1.1.0",
-                "libp2p-crypto": "^0.21.0",
-                "multiformats": "^9.4.5",
-                "protobufjs": "^6.10.2",
-                "uint8arrays": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=15.0.0"
-            }
-        },
-        "node_modules/peer-id/node_modules/multiformats": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-            "license": "(Apache-2.0 AND MIT)"
-        },
-        "node_modules/peer-id/node_modules/uint8arrays": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-            "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-            "license": "MIT",
-            "dependencies": {
-                "multiformats": "^9.4.2"
-            }
-        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -24384,17 +24218,17 @@
             }
         },
         "node_modules/rpc-websockets": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.1.tgz",
-            "integrity": "sha512-bY6a+i/lEtBJ/mUxwsCTgevoV1P0foXTVA7UoThzaIWbM+3NDqorf8NBWs5DmqKTFeA1IoNzgvkWjFCPgnzUiQ==",
+            "version": "9.3.8",
+            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.8.tgz",
+            "integrity": "sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==",
             "license": "LGPL-3.0-only",
             "dependencies": {
                 "@swc/helpers": "^0.5.11",
-                "@types/uuid": "^8.3.4",
+                "@types/uuid": "^10.0.0",
                 "@types/ws": "^8.2.2",
                 "buffer": "^6.0.3",
                 "eventemitter3": "^5.0.1",
-                "uuid": "^8.3.2",
+                "uuid": "^11.0.0",
                 "ws": "^8.5.0"
             },
             "funding": {
@@ -24403,16 +24237,34 @@
             },
             "optionalDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": "^6.0.0"
+            }
+        },
+        "node_modules/rpc-websockets/node_modules/utf-8-validate": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+            "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
             }
         },
         "node_modules/rpc-websockets/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/run-applescript": {
@@ -26860,6 +26712,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
             },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.16",
+        "@pkcprotocol/pkc-js": "0.0.17",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -257,6 +257,8 @@ export default class Daemon extends Command {
         defaultPkcOptions.kuboRpcClientsOptions = [kuboRpcEndpoint.toString()];
         const mergedPkcOptions = { ...defaultPkcOptions, ...pkcOptionsFromFlag };
         log("Merged pkc options that will be used for this node", mergedPkcOptions);
+        const { nameResolvers: _nr, ...printablePkcOptions } = mergedPkcOptions;
+        console.log("PKC options:", JSON.stringify(printablePkcOptions, null, 2));
 
         // Migrate data directory before creating PKC instance
         migrateDataDirectory(mergedPkcOptions.dataPath!);
@@ -271,6 +273,7 @@ export default class Daemon extends Command {
         // Create BSO name resolvers for .bso/.eth domain resolution
         const bsoResolvers = createBsoResolvers(flags.chainProviderUrls, mergedPkcOptions.dataPath);
         mergedPkcOptions.nameResolvers = [...(mergedPkcOptions.nameResolvers || []), ...bsoResolvers];
+        console.log(".bso name resolvers:", bsoResolvers.map((r) => r.provider).join(", "));
 
         let mainProcessExited = false;
         let pendingKuboStart: Promise<ChildProcessWithoutNullStreams> | undefined;

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -19,6 +19,7 @@ import { printBanner } from "../ascii-banner.js";
 import { loadChallengesIntoPKC } from "../../challenge-packages/challenge-utils.js";
 import { migrateDataDirectory } from "../../common-utils/data-migration.js";
 import { createBsoResolvers } from "../../common-utils/resolvers.js";
+import { pruneStaleStates, writeDaemonState, deleteDaemonState } from "../../common-utils/daemon-state.js";
 import fs from "fs";
 import fsPromise from "fs/promises";
 
@@ -260,6 +261,13 @@ export default class Daemon extends Command {
         // Migrate data directory before creating PKC instance
         migrateDataDirectory(mergedPkcOptions.dataPath!);
 
+        // Prune stale daemon state files (dead PIDs from crashed daemons)
+        await pruneStaleStates();
+
+        // Persist this daemon's PID and startup args so `bitsocial update install --restart-daemons` can stop and restart it
+        const daemonArgv = process.argv.slice(process.argv.indexOf("daemon") + 1);
+        await writeDaemonState({ pid: process.pid, startedAt: new Date().toISOString(), argv: daemonArgv, pkcRpcUrl: pkcRpcUrl.toString() });
+
         // Create BSO name resolvers for .bso/.eth domain resolution
         const bsoResolvers = createBsoResolvers(flags.chainProviderUrls, mergedPkcOptions.dataPath);
         mergedPkcOptions.nameResolvers = [...(mergedPkcOptions.nameResolvers || []), ...bsoResolvers];
@@ -480,6 +488,9 @@ export default class Daemon extends Command {
                 log("Received signal to exit, shutting down both kubo and pkc rpc. Please wait, it may take a few seconds");
 
                 mainProcessExited = true;
+
+                // Remove daemon state file so update install knows we're gone
+                await deleteDaemonState(process.pid).catch(() => {});
 
                 // Start killing Kubo immediately, in parallel with daemon server destroy.
                 // This way Kubo receives SIGINT right away, even if daemonServer.destroy() hangs.

--- a/src/cli/commands/update/install.ts
+++ b/src/cli/commands/update/install.ts
@@ -1,8 +1,9 @@
 import { Args, Flags, Command } from "@oclif/core";
+import { spawn } from "child_process";
 import tcpPortUsed from "tcp-port-used";
-import defaults from "../../../common-utils/defaults.js";
 import { fetchLatestVersion, installGlobal } from "../../../update/npm-registry.js";
 import { compareVersions } from "../../../update/semver.js";
+import { getAliveDaemonStates, type DaemonState } from "../../../common-utils/daemon-state.js";
 
 export default class Install extends Command {
     static override description = "Install a specific version of bitsocial from npm";
@@ -19,6 +20,11 @@ export default class Install extends Command {
         force: Flags.boolean({
             description: "Reinstall even if already on the requested version",
             default: false
+        }),
+        "restart-daemons": Flags.boolean({
+            description: "Stop all running daemons, update, and restart them with the same settings",
+            default: true,
+            allowNo: true
         })
     };
 
@@ -26,20 +32,50 @@ export default class Install extends Command {
         "bitsocial update install",
         "bitsocial update install latest",
         "bitsocial update install 0.19.40",
-        "bitsocial update install --force"
+        "bitsocial update install --force",
+        "bitsocial update install --no-restart-daemons"
     ];
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(Install);
 
-        // Check if daemon is running — refuse to update while it's active
-        const rpcPort = Number(defaults.PKC_RPC_URL.port);
-        const daemonRunning = await tcpPortUsed.check(rpcPort, "127.0.0.1").catch(() => false);
-        if (daemonRunning) {
-            this.error(
-                `Daemon is running on port ${rpcPort}. Stop it first with Ctrl-C, then run 'bitsocial update install'.`,
-                { exit: 1 }
-            );
+        // Check for running daemons via state files
+        const aliveDaemons = await getAliveDaemonStates();
+
+        if (aliveDaemons.length > 0) {
+            if (!flags["restart-daemons"]) {
+                this.error(
+                    `${aliveDaemons.length} daemon(s) running. Stop them first, then retry.`,
+                    { exit: 1 }
+                );
+            }
+
+            // Stop all running daemons
+            for (const d of aliveDaemons) {
+                this.log(`Stopping daemon (PID ${d.pid})...`);
+                try {
+                    process.kill(d.pid, "SIGINT");
+                } catch (e) {
+                    if ((e as NodeJS.ErrnoException).code === "ESRCH") {
+                        this.log(`  PID ${d.pid} already exited.`);
+                        continue;
+                    }
+                    throw e;
+                }
+            }
+
+            // Wait for all daemon ports to be free
+            for (const d of aliveDaemons) {
+                const url = new URL(d.pkcRpcUrl);
+                const port = Number(url.port);
+                const host = url.hostname;
+                this.log(`Waiting for port ${port} to be free...`);
+                const freed = await tcpPortUsed.waitUntilFree(port, 500, 30000).then(() => true).catch(() => false);
+                if (!freed) {
+                    this.error(`Daemon (PID ${d.pid}) did not shut down within 30 seconds on port ${port}.`, { exit: 1 });
+                }
+            }
+            this.log("All daemons stopped.");
         }
 
         // Resolve the target version
@@ -59,6 +95,10 @@ export default class Install extends Command {
         // Skip if already on this version (unless --force)
         if (compareVersions(current, targetVersion) === 0 && !flags.force) {
             this.log(`Already on v${current}. Use --force to reinstall.`);
+            if (aliveDaemons.length > 0 && flags["restart-daemons"]) {
+                // We stopped daemons but don't need to update — restart them
+                await this._restartDaemons(aliveDaemons);
+            }
             return;
         }
 
@@ -71,5 +111,40 @@ export default class Install extends Command {
         }
 
         this.log(`Installed bitsocial v${targetVersion} (was v${current}).`);
+
+        // Restart daemons with the new binary
+        if (aliveDaemons.length > 0 && flags["restart-daemons"]) {
+            await this._restartDaemons(aliveDaemons);
+        }
+    }
+
+    private async _restartDaemons(daemons: DaemonState[]): Promise<void> {
+        this.log(`Restarting ${daemons.length} daemon(s)...`);
+
+        for (const d of daemons) {
+            const argStr = d.argv.length > 0 ? d.argv.join(" ") : "(defaults)";
+            this.log(`  Starting daemon with args: ${argStr}`);
+
+            const child = spawn("bitsocial", ["daemon", ...d.argv], {
+                detached: true,
+                stdio: "ignore"
+            });
+            child.unref();
+
+            if (!child.pid) {
+                this.warn(`Failed to spawn daemon for args: ${argStr}`);
+                continue;
+            }
+
+            // Wait briefly for the daemon's RPC port to come up
+            const url = new URL(d.pkcRpcUrl);
+            const port = Number(url.port);
+            const started = await tcpPortUsed.waitUntilUsed(port, 500, 30000).then(() => true).catch(() => false);
+            if (started) {
+                this.log(`  Daemon started (port ${port}).`);
+            } else {
+                this.warn(`  Daemon may not have started — port ${port} not responding after 30s. Check logs with: bitsocial logs`);
+            }
+        }
     }
 }

--- a/src/common-utils/daemon-state.ts
+++ b/src/common-utils/daemon-state.ts
@@ -1,0 +1,92 @@
+import defaults from "./defaults.js";
+import path from "path";
+import fs from "fs/promises";
+
+const DAEMON_STATES_DIR = path.join(defaults.PKC_DATA_PATH, ".daemon_states");
+
+export interface DaemonState {
+    pid: number;
+    startedAt: string;
+    argv: string[];
+    pkcRpcUrl: string;
+}
+
+function stateFilePath(pid: number): string {
+    return path.join(DAEMON_STATES_DIR, `${pid}-daemon.state`);
+}
+
+/** Write a daemon state file atomically (write to .tmp then rename). */
+export async function writeDaemonState(state: DaemonState): Promise<void> {
+    await fs.mkdir(DAEMON_STATES_DIR, { recursive: true });
+    const dest = stateFilePath(state.pid);
+    const tmp = dest + ".tmp";
+    await fs.writeFile(tmp, JSON.stringify(state, null, 2));
+    await fs.rename(tmp, dest);
+}
+
+/** Read all state files from the daemon states directory. */
+export async function readAllDaemonStates(): Promise<DaemonState[]> {
+    let entries: string[];
+    try {
+        entries = await fs.readdir(DAEMON_STATES_DIR);
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw e;
+    }
+
+    const states: DaemonState[] = [];
+    for (const entry of entries) {
+        if (!entry.endsWith("-daemon.state")) continue;
+        try {
+            const content = await fs.readFile(path.join(DAEMON_STATES_DIR, entry), "utf-8");
+            states.push(JSON.parse(content) as DaemonState);
+        } catch {
+            // Corrupted or partially written — skip
+        }
+    }
+    return states;
+}
+
+/** Delete a specific daemon's state file. Ignores ENOENT. */
+export async function deleteDaemonState(pid: number): Promise<void> {
+    try {
+        await fs.unlink(stateFilePath(pid));
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+}
+
+/** Check whether a PID is alive. */
+function isPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "EPERM") return true; // alive but owned by another user
+        return false; // ESRCH — no such process
+    }
+}
+
+/** Delete state files for dead PIDs from disk. */
+export async function pruneStaleStates(): Promise<void> {
+    const states = await readAllDaemonStates();
+    for (const state of states) {
+        if (!isPidAlive(state.pid)) {
+            await deleteDaemonState(state.pid);
+        }
+    }
+}
+
+/** Read all states, delete stale files (dead PIDs) from disk, return only alive ones. */
+export async function getAliveDaemonStates(): Promise<DaemonState[]> {
+    const states = await readAllDaemonStates();
+    const alive: DaemonState[] = [];
+    for (const state of states) {
+        if (isPidAlive(state.pid)) {
+            alive.push(state);
+        } else {
+            await deleteDaemonState(state.pid);
+        }
+    }
+    return alive;
+}

--- a/test/cli/daemon.test.ts
+++ b/test/cli/daemon.test.ts
@@ -920,6 +920,13 @@ describe("bitsocial daemon DEBUG env var", () => {
             expect(daemonProcess.capturedStdout).toContain("To view logs, run: bitsocial logs");
             expect(daemonProcess.capturedStdout).toContain("DEBUG");
 
+            // stdout should contain the printed PKC options
+            expect(daemonProcess.capturedStdout).toContain("PKC options:");
+            expect(daemonProcess.capturedStdout).toContain('"dataPath"');
+
+            // stdout should contain BSO resolver info
+            expect(daemonProcess.capturedStdout).toContain(".bso name resolvers:");
+
             // Should NOT contain "Debug logs is on" since no DEBUG was set
             expect(daemonProcess.capturedStderr).not.toContain("Debug logs is on");
         } finally {

--- a/test/common-utils/daemon-state.test.ts
+++ b/test/common-utils/daemon-state.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { directory as randomDirectory } from "tempy";
+
+// We test the functions by importing them, but they use a hardcoded DAEMON_STATES_DIR.
+// To isolate tests, we test the logic directly with a custom dir via the module internals.
+// Since the module uses a fixed path, we'll test by writing/reading actual state files
+// in the real states dir, then cleaning up.
+
+// Import the actual functions
+import {
+    writeDaemonState,
+    readAllDaemonStates,
+    deleteDaemonState,
+    getAliveDaemonStates,
+    pruneStaleStates
+} from "../../dist/common-utils/daemon-state.js";
+import type { DaemonState } from "../../dist/common-utils/daemon-state.js";
+
+// Use a PID range that definitely doesn't exist (very large PIDs)
+const FAKE_PID_BASE = 9999900;
+let fakePidCounter = 0;
+const nextFakePid = () => FAKE_PID_BASE + ++fakePidCounter;
+
+const makeState = (pid: number): DaemonState => ({
+    pid,
+    startedAt: new Date().toISOString(),
+    argv: ["--pkcRpcUrl", `ws://localhost:${9000 + pid}`],
+    pkcRpcUrl: `ws://localhost:${9000 + pid}`
+});
+
+describe("daemon-state", () => {
+    const createdPids: number[] = [];
+
+    afterEach(async () => {
+        // Clean up any state files we created
+        for (const pid of createdPids) {
+            await deleteDaemonState(pid);
+        }
+        createdPids.length = 0;
+    });
+
+    describe("writeDaemonState + readAllDaemonStates", () => {
+        it("should write and read a state file", async () => {
+            const pid = nextFakePid();
+            createdPids.push(pid);
+            const state = makeState(pid);
+
+            await writeDaemonState(state);
+            const all = await readAllDaemonStates();
+
+            const found = all.find((s) => s.pid === pid);
+            expect(found).toBeDefined();
+            expect(found!.argv).toEqual(state.argv);
+            expect(found!.pkcRpcUrl).toBe(state.pkcRpcUrl);
+        });
+
+        it("should write multiple state files", async () => {
+            const pid1 = nextFakePid();
+            const pid2 = nextFakePid();
+            createdPids.push(pid1, pid2);
+
+            await writeDaemonState(makeState(pid1));
+            await writeDaemonState(makeState(pid2));
+
+            const all = await readAllDaemonStates();
+            const pids = all.map((s) => s.pid);
+            expect(pids).toContain(pid1);
+            expect(pids).toContain(pid2);
+        });
+    });
+
+    describe("deleteDaemonState", () => {
+        it("should delete a state file", async () => {
+            const pid = nextFakePid();
+            createdPids.push(pid);
+
+            await writeDaemonState(makeState(pid));
+            await deleteDaemonState(pid);
+
+            const all = await readAllDaemonStates();
+            expect(all.find((s) => s.pid === pid)).toBeUndefined();
+        });
+
+        it("should not throw when deleting non-existent state", async () => {
+            await expect(deleteDaemonState(nextFakePid())).resolves.not.toThrow();
+        });
+    });
+
+    describe("getAliveDaemonStates", () => {
+        it("should return only alive PIDs and delete stale files", async () => {
+            const stalePid = nextFakePid();
+            createdPids.push(stalePid);
+            await writeDaemonState(makeState(stalePid));
+
+            // stalePid doesn't exist as a process, so it should be pruned
+            const alive = await getAliveDaemonStates();
+            expect(alive.find((s) => s.pid === stalePid)).toBeUndefined();
+
+            // The file should have been deleted from disk
+            const all = await readAllDaemonStates();
+            expect(all.find((s) => s.pid === stalePid)).toBeUndefined();
+        });
+
+        it("should return the current process PID as alive", async () => {
+            const myPid = process.pid;
+            createdPids.push(myPid);
+            await writeDaemonState(makeState(myPid));
+
+            const alive = await getAliveDaemonStates();
+            expect(alive.find((s) => s.pid === myPid)).toBeDefined();
+        });
+    });
+
+    describe("pruneStaleStates", () => {
+        it("should remove state files for dead PIDs", async () => {
+            const stalePid = nextFakePid();
+            createdPids.push(stalePid);
+            await writeDaemonState(makeState(stalePid));
+
+            await pruneStaleStates();
+
+            const all = await readAllDaemonStates();
+            expect(all.find((s) => s.pid === stalePid)).toBeUndefined();
+        });
+
+        it("should keep state files for alive PIDs", async () => {
+            const myPid = process.pid;
+            createdPids.push(myPid);
+            await writeDaemonState(makeState(myPid));
+
+            await pruneStaleStates();
+
+            const all = await readAllDaemonStates();
+            expect(all.find((s) => s.pid === myPid)).toBeDefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Upgrades `@pkcprotocol/pkc-js` from 0.0.16 to 0.0.17 (latest)
- Build and all 156 tests pass locally

## Test plan
- [x] `npm run build && npm run build:test` passes
- [x] `npm run test:cli` — all 156 tests pass (0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to explicitly require Node.js 22 or later
  * Added recommendation to use nvm for installing and managing Node.js versions

* **New Features**
  * Added `--restart-daemons` flag to the update install command, enabling automatic daemon process restart during CLI upgrades (enabled by default)

* **Chores**
  * Updated @pkcprotocol/pkc-js dependency to version 0.0.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->