### PR TITLE
ci(docker): build from the release tag instead of pre-release SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,26 +1,36 @@
 name: Docker Publish
 
 on:
-  workflow_run:
-    workflows:
-      - "CI build"
-    types:
-      - "completed"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and publish (e.g. v0.19.57)"
+        required: true
 
 jobs:
   docker-test:
     name: Build and test Docker image
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
+      - name: Resolve release tag
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ steps.ref.outputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -114,22 +124,26 @@ jobs:
     name: Push Docker image
     needs:
       - docker-test
-    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.docker-test.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Resolve release tag
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Get latest release tag
-        id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@v2
+          ref: ${{ steps.ref.outputs.tag }}
 
       - name: Docker meta
         id: meta
@@ -137,9 +151,9 @@ jobs:
         with:
           images: ghcr.io/bitsocialnet/bitsocial-cli
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.previoustag.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.previoustag.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ steps.previoustag.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ steps.ref.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ref.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ steps.ref.outputs.tag }}
             type=raw,value=latest
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary

- Switches `.github/workflows/docker-publish.yml` from `workflow_run` → `release: types: [published]` so the image is built from the actual release commit (the tag), not the SHA that triggered the upstream CI run.
- Both jobs now check out `github.event.release.tag_name` (or the `tag` workflow_dispatch input).
- Adds `workflow_dispatch` with a `tag` input so past releases can be re-published manually — useful for fixing `0.19.57` once this lands.

## Why this fixes #38

The previous flow: push → `CI` runs on SHA X → `CI build` runs on master, release-it bumps to vX.Y.Z, commits `chore(release): X.Y.Z [skip ci]`, tags, and pushes → `Docker Publish` (workflow_run-triggered) checks out **SHA X** (the pre-release commit) but labels the image with **vX.Y.Z**. Result: every published image is one release behind.

`on: push: tags:` would not work because the release commit carries `[skip ci]` and that suppresses tag pushes too. `release: published` is unaffected by `[skip ci]` and release-it already creates a real GitHub Release (`github.release: true` in `config/.release-it.json`).

## Test plan

- [ ] Merge to master; confirm no auto-trigger of `Docker Publish` (there's no release event from the merge itself).
- [ ] Manually re-publish `v0.19.57`: Actions → Docker Publish → Run workflow → tag `v0.19.57`. Verify the pushed image's `bitsocial --version` reports `0.19.57`.
- [ ] On the next real release, confirm `:latest` and `:0.19.58` both contain the correct binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflow to streamline release automation and improve tagging consistency for published releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->