### PR TITLE
fix(logs): drop stale-stat gate that hid appends on Windows

### DIFF
--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -198,40 +198,49 @@ export default class Logs extends Command {
         let position = stat.size;
         let pendingBuffer = "";
 
-        // Watch for new data using polling (works across filesystems including Docker volumes)
+        // Watch for new data by reading directly from `position`. We intentionally do
+        // NOT gate on fsPromise.stat().size — on Windows + NTFS, stat() returns a stale
+        // size for a short window after another process appends, which causes the gate
+        // to miss new bytes. read() sees the true file end at syscall time.
+        const READ_BUF_SIZE = 64 * 1024;
+        const readBuf = Buffer.alloc(READ_BUF_SIZE);
         const readNewData = async () => {
+            let fd: fsPromise.FileHandle | undefined;
             try {
-                const currentStat = await fsPromise.stat(currentLogFile);
-                if (currentStat.size > position) {
-                    const fd = await fsPromise.open(currentLogFile, "r");
-                    const buf = new Uint8Array(currentStat.size - position);
-                    const { bytesRead } = await fd.read(buf, 0, buf.length, position);
-                    await fd.close();
+                fd = await fsPromise.open(currentLogFile, "r");
+                let chunk = "";
+                while (true) {
+                    const { bytesRead } = await fd.read(readBuf, 0, readBuf.length, position);
+                    if (bytesRead === 0) break;
                     position += bytesRead;
+                    chunk += readBuf.subarray(0, bytesRead).toString("utf-8");
+                    if (bytesRead < readBuf.length) break;
+                }
+                if (!chunk) return;
 
-                    const chunk = pendingBuffer + new TextDecoder().decode(buf.subarray(0, bytesRead));
-                    // Split into complete lines; keep any incomplete trailing line in the buffer
-                    const lastNewline = chunk.lastIndexOf("\n");
-                    if (lastNewline === -1) {
-                        pendingBuffer = chunk;
-                        return;
-                    }
-                    pendingBuffer = chunk.slice(lastNewline + 1);
-                    const completeText = chunk.slice(0, lastNewline + 1);
+                const combined = pendingBuffer + chunk;
+                const lastNewline = combined.lastIndexOf("\n");
+                if (lastNewline === -1) {
+                    pendingBuffer = combined;
+                    return;
+                }
+                pendingBuffer = combined.slice(lastNewline + 1);
+                const completeText = combined.slice(0, lastNewline + 1);
 
-                    if (!since && !until && !streamFilter) {
-                        // No filtering — pass through directly
-                        process.stdout.write(completeText);
-                    } else {
-                        const newEntries = this._parseLogEntries(completeText.replace(/\n$/, ""));
-                        const filteredNew = this._filterEntries(newEntries, since, until);
-                        const streamFilteredNew = streamFilter ? this._filterByStream(filteredNew, streamFilter) : filteredNew;
-                        const output = streamFilteredNew.map((e) => e.lines.join("\n")).join("\n");
-                        if (output) process.stdout.write(output + "\n");
-                    }
+                if (!since && !until && !streamFilter) {
+                    // No filtering — pass through directly
+                    process.stdout.write(completeText);
+                } else {
+                    const newEntries = this._parseLogEntries(completeText.replace(/\n$/, ""));
+                    const filteredNew = this._filterEntries(newEntries, since, until);
+                    const streamFilteredNew = streamFilter ? this._filterByStream(filteredNew, streamFilter) : filteredNew;
+                    const output = streamFilteredNew.map((e) => e.lines.join("\n")).join("\n");
+                    if (output) process.stdout.write(output + "\n");
                 }
             } catch {
                 // File may have been rotated or deleted
+            } finally {
+                if (fd) await fd.close().catch(() => {});
             }
         };
 


### PR DESCRIPTION
## Summary

- The earlier fix (#41) replaced `fs.watchFile` with userspace polling but kept the `fsPromise.stat(file).size > position` gate. On Windows + NTFS, `stat()` returns a stale size for a short window after another process appends, so the gate stays false and the read never fires. Linux/macOS update size promptly, masking the bug — which is why CI passed there but the windows-latest job continued to fail at `test/cli/logs.test.ts:462` (`expected … to contain 'APPENDED_LINE'`).
- This PR drops the gate and reads directly from `position` in a loop until `read()` returns 0 bytes. `read()` sees the true file end at syscall time and doesn't depend on metadata being fresh.
- Re-opens #40 (its previous closure was premature).

## Test plan

- [x] `npm run build && npm run build:test`
- [x] `npx vitest run test/cli/logs.test.ts` — all 29 tests pass locally on Linux (including the `continues watching old file if no new file appears` regression case).
- [ ] CI windows-latest job passes (the actual regression we're targeting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the efficiency of `bitsocial logs --follow` command by optimizing how log files are monitored and tailed. The command now reads log updates more efficiently and better handles incomplete log lines when filtering or streaming output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->