### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js to 0.0.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.35",
+                "@pkcprotocol/pkc-js": "0.0.37",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5421,9 +5421,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.35",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.35.tgz",
-            "integrity": "sha512-5E5cqYvM7AKBnzVZlVCgHrkQX0X3dWaasnzKOO+dq1nq9llvm9/sHmxanRAk1JMo2cH18aPTp9q7cJ83NvtfPw==",
+            "version": "0.0.37",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.37.tgz",
+            "integrity": "sha512-jIdsEl2DpAGbhJGFAKGvVgFT0lO5Nwy6TDhqQmXCVcBzAI/DohRXEG4Q0QWuFoRbstFSxL8FA0pRKhLFoZMFlA==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.35",
+        "@pkcprotocol/pkc-js": "0.0.37",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",


### PR DESCRIPTION
## Summary
- Bumps `@pkcprotocol/pkc-js` from 0.0.35 → 0.0.37 (exact pin).

Closes #50

## Test plan
- [x] `npm run build && npm run build:test` passes
- [x] `npm run test:cli` — 208 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PKC protocol library dependency to the latest version for maintenance and improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->