### PR TITLE
fix(daemon-server): await express listen() so RPC port is bound before startup completes

### DIFF
--- a/src/webui/daemon-server.ts
+++ b/src/webui/daemon-server.ts
@@ -46,7 +46,23 @@ export async function startDaemonServer(rpcUrl: URL, ipfsGatewayUrl: URL, pkcOpt
     // Start pkc-js RPC
     const log = PKCLogger("bitsocial-cli:daemon:startDaemonServer");
     const webuiExpressApp = express();
-    const httpServer = webuiExpressApp.listen(Number(rpcUrl.port));
+    // Wait for bind to actually complete before returning. Calling express.listen() without
+    // awaiting 'listening' lets startup proceed before the port is accepting connections,
+    // and without an 'error' handler a bind failure becomes an uncaughtException that kills
+    // the daemon *after* it has already logged "Communities in data path" — see issue #42.
+    const httpServer = await new Promise<import("http").Server>((resolve, reject) => {
+        const server = webuiExpressApp.listen(Number(rpcUrl.port));
+        const onListening = () => {
+            server.off("error", onError);
+            resolve(server);
+        };
+        const onError = (err: Error) => {
+            server.off("listening", onListening);
+            reject(err);
+        };
+        server.once("listening", onListening);
+        server.once("error", onError);
+    });
     log("HTTP server is running on", "0.0.0.0" + ":" + rpcUrl.port);
     const rpcAuthKey = await _generateRpcAuthKeyIfNotExisting(pkcOptions.dataPath!);
     const PKCRpc = await import("@pkcprotocol/pkc-js/rpc");

--- a/test/webui/daemon-server.test.ts
+++ b/test/webui/daemon-server.test.ts
@@ -11,11 +11,11 @@ import { startDaemonServer } from "../../dist/webui/daemon-server.js";
 // The contract we want: if the port can't be bound, startDaemonServer must reject.
 describe("startDaemonServer bind contract", () => {
     it("rejects when the RPC port is already taken (regression for issue #42)", async () => {
-        // Blocker must bind to 0.0.0.0 because express.listen(port) (no host arg) also
-        // binds to 0.0.0.0. On BSD-derived stacks (macOS, Windows) a wildcard bind and
-        // a 127.0.0.1 bind on the same port can coexist, so binding the blocker to
-        // 127.0.0.1 would let the daemon's wildcard bind succeed and the test wouldn't
-        // exercise the EADDRINUSE path.
+        // The blocker must bind the *same way* the daemon does — no host argument —
+        // so it lands on whatever default Node picks for this platform. On macOS and
+        // Windows that default is the IPv6 wildcard `::` with IPV6_V6ONLY=true, which
+        // does NOT conflict with a 0.0.0.0 bind. Binding the blocker to 127.0.0.1 or
+        // 0.0.0.0 would let the daemon's listen succeed there and never hit EADDRINUSE.
         const blocker = net.createServer();
         const port = await new Promise<number>((resolve, reject) => {
             blocker.once("listening", () => {
@@ -24,7 +24,7 @@ describe("startDaemonServer bind contract", () => {
                 else reject(new Error(`unexpected address ${JSON.stringify(addr)}`));
             });
             blocker.once("error", reject);
-            blocker.listen(0, "0.0.0.0");
+            blocker.listen(0);
         });
 
         // Swallow any stray uncaughtException emitted by an unguarded server.listen()

--- a/test/webui/daemon-server.test.ts
+++ b/test/webui/daemon-server.test.ts
@@ -11,6 +11,11 @@ import { startDaemonServer } from "../../dist/webui/daemon-server.js";
 // The contract we want: if the port can't be bound, startDaemonServer must reject.
 describe("startDaemonServer bind contract", () => {
     it("rejects when the RPC port is already taken (regression for issue #42)", async () => {
+        // Blocker must bind to 0.0.0.0 because express.listen(port) (no host arg) also
+        // binds to 0.0.0.0. On BSD-derived stacks (macOS, Windows) a wildcard bind and
+        // a 127.0.0.1 bind on the same port can coexist, so binding the blocker to
+        // 127.0.0.1 would let the daemon's wildcard bind succeed and the test wouldn't
+        // exercise the EADDRINUSE path.
         const blocker = net.createServer();
         const port = await new Promise<number>((resolve, reject) => {
             blocker.once("listening", () => {
@@ -19,7 +24,7 @@ describe("startDaemonServer bind contract", () => {
                 else reject(new Error(`unexpected address ${JSON.stringify(addr)}`));
             });
             blocker.once("error", reject);
-            blocker.listen(0, "127.0.0.1");
+            blocker.listen(0, "0.0.0.0");
         });
 
         // Swallow any stray uncaughtException emitted by an unguarded server.listen()

--- a/test/webui/daemon-server.test.ts
+++ b/test/webui/daemon-server.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import net from "net";
+import { directory as randomDirectory } from "tempy";
+import { startDaemonServer } from "../../dist/webui/daemon-server.js";
+
+// Regression test for issue #42:
+// startDaemonServer used to call webuiExpressApp.listen(port) fire-and-forget — no
+// await on 'listening', no 'error' handler. If bind failed, the promise still resolved
+// and the bind error showed up later as an uncaughtException, crashing the daemon
+// AFTER the test helper had already accepted "Communities in data path" as readiness.
+// The contract we want: if the port can't be bound, startDaemonServer must reject.
+describe("startDaemonServer bind contract", () => {
+    it("rejects when the RPC port is already taken (regression for issue #42)", async () => {
+        const blocker = net.createServer();
+        const port = await new Promise<number>((resolve, reject) => {
+            blocker.once("listening", () => {
+                const addr = blocker.address();
+                if (addr && typeof addr === "object") resolve(addr.port);
+                else reject(new Error(`unexpected address ${JSON.stringify(addr)}`));
+            });
+            blocker.once("error", reject);
+            blocker.listen(0, "127.0.0.1");
+        });
+
+        // Swallow any stray uncaughtException emitted by an unguarded server.listen()
+        // so the test process survives long enough to assert the actual behavior.
+        const stray: Error[] = [];
+        const uncaughtHandler = (err: Error) => stray.push(err);
+        process.on("uncaughtException", uncaughtHandler);
+
+        try {
+            await expect(
+                startDaemonServer(
+                    new URL(`ws://127.0.0.1:${port}`),
+                    new URL("http://127.0.0.1:6754"),
+                    { dataPath: randomDirectory() }
+                )
+            ).rejects.toThrow(/EADDRINUSE|address already in use/i);
+            // And no stray uncaughtException either — the bind error must come back
+            // through the promise, not the process.
+            expect(stray).toEqual([]);
+        } finally {
+            process.off("uncaughtException", uncaughtHandler);
+            await new Promise<void>((resolve) => blocker.close(() => resolve()));
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Root-cause fix for the intermittent `ECONNREFUSED 127.0.0.1:39138` failure in `test/cli/daemon.test.ts > bitsocial daemon webui > 5chan webui does not contain the hash redirect script` (most recent occurrence: [run 26333018289](https://github.com/bitsocialnet/bitsocial-cli/actions/runs/26333018289/job/77522107131)).
- `src/webui/daemon-server.ts` was calling `webuiExpressApp.listen(port)` fire-and-forget — no `await` on `'listening'`, no `'error'` handler. `startDaemonServer` could return (and the daemon could log `Communities in data path`, which the test helper treats as readiness) before the OS had finished binding the RPC port. Worse, a bind failure surfaced asynchronously as an unhandled `'error'` event → `uncaughtException` → daemon crashed *after* it had already advertised itself as ready.
- Wrap `listen()` in a promise that resolves on `'listening'` and rejects on `'error'`. Now `startDaemonServer` only returns once the port is bound, and bind failures propagate through the normal rejection path instead of killing the process.
- Adds `test/webui/daemon-server.test.ts` with a deterministic reproducer that pre-binds the port and asserts `startDaemonServer` rejects with `EADDRINUSE`. Fails on the old code (resolves successfully with broken server), passes after the fix in ~12ms.

## Test plan

- [x] New reproducer (`test/webui/daemon-server.test.ts`) fails on `master`, passes on this branch.
- [x] Full `test/cli/daemon.test.ts` suite (22 tests, includes the flaky webui suite) passes locally.
- [ ] CI green on ubuntu/macOS/Windows.

Fixes #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon server startup now waits for the HTTP server to finish binding so port conflicts are detected and reported immediately instead of causing uncaught exceptions.

* **Tests**
  * Added a regression test ensuring startup rejects when required ports are in use and that no uncaught exceptions are emitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->