### PR TITLE
feat(update): hint at `bitsocial logs --stdout` after restarting daemons

### DIFF
--- a/src/cli/commands/update/install.ts
+++ b/src/cli/commands/update/install.ts
@@ -130,6 +130,7 @@ export default class Install extends Command {
         // Restart daemons with the new binary
         if (aliveDaemons.length > 0 && flags["restart-daemons"]) {
             await this._restartDaemons(aliveDaemons);
+            this.log("To see the daemon logs run `bitsocial logs --stdout`");
         }
     }
 


### PR DESCRIPTION
## Summary

- After `bitsocial update install` installs a new version and restarts the previously-running daemon(s), print a one-line hint pointing the user at `bitsocial logs --stdout`.
- The restart spawns the new daemon detached with `stdio: "ignore"`, so the user loses visibility on the web UI links and other stdout output from the old daemon. This hint shows them how to recover that output from the new daemon.

The message only fires when a **new** version was actually installed AND daemons were running (i.e. the user genuinely lost stdout access). It is suppressed on the "already on this version" path and when no daemons were running.

Closes #55

## Test plan

- [ ] Manually run `bitsocial update install <newer-version>` with a running daemon and confirm the hint appears after the restart block.
- [ ] Run `bitsocial update install <same-version>` with a running daemon and confirm the hint does NOT appear (no new install happened).
- [ ] Run `bitsocial update install <newer-version>` with no running daemon and confirm the hint does NOT appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing instruction message that appears during daemon restarts after CLI updates, directing users to the daemon log command for additional information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->