### PR TITLE
[codex] fix 5chan hash redirect behind daemon

### DIFF
--- a/src/webui/daemon-server.ts
+++ b/src/webui/daemon-server.ts
@@ -9,10 +9,13 @@ import { randomBytes } from "crypto";
 import express from "express";
 import { loadChallengesIntoPKC } from "../challenge-packages/challenge-utils.js";
 
+const rootHashRedirectScriptPattern =
+    /<script\b[^>]*>(?:(?!<\/script>)[\s\S])*?window\.location\.replace\(["']\/#["']\s*\+\s*window\.location\.pathname\s*\+\s*window\.location\.search\);(?:(?!<\/script>)[\s\S])*?<\/script>/;
+
 async function _generateModifiedIndexHtmlWithRpcSettings(webuiPath: string, webuiName: string, ipfsGatewayPort: number) {
     const indexHtmlString = (await fs.readFile(path.join(webuiPath, "index_backup_no_rpc.html")))
         .toString()
-        .replace(/<script>\s*\/\/\s*Redirect non-hash URLs[\s\S]*?<\/script>/, "");
+        .replace(rootHashRedirectScriptPattern, "");
     const defaultRpcOptionString = `[window.location.origin.replace("https://", "wss://").replace("http://", "ws://") + window.location.pathname.split('/' + '${webuiName}')[0]]`;
     // Ipfs media only locally because ipfs gateway doesn't allow remote connections
     const defaultIpfsMedia = `if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1" || window.location.hostname === "0.0.0.0")window.defaultMediaIpfsGatewayUrl = 'http://' + window.location.hostname + ':' + ${ipfsGatewayPort}`;

--- a/test/cli/daemon.test.ts
+++ b/test/cli/daemon.test.ts
@@ -715,11 +715,13 @@ describe(`bitsocial daemon webui`, async () => {
         await stopPkcDaemon(daemonProcess);
     });
 
-    it(`5chan webui does not contain the hash redirect script`, async () => {
+    it(`5chan webui does not contain the root hash redirect script`, async () => {
         const res = await fetch(`http://localhost:${rpcUrl.port}/5chan`);
         expect(res.status).toBe(200);
         const html = await res.text();
-        expect(html).not.toMatch(/Redirect non-hash URLs/);
+        expect(html).not.toMatch(
+            /window\.location\.replace\(["']\/#["']\s*\+\s*window\.location\.pathname\s*\+\s*window\.location\.search\)/
+        );
     });
 
     it(`POST /api/challenges/reload returns 200 for local connections`, async () => {


### PR DESCRIPTION
## Summary
- Strip 5chan's inline root hash redirect by matching the actual `window.location.replace('/#' + window.location.pathname + window.location.search)` call instead of relying on the old comment text.
- Tighten the daemon web UI regression test so it fails if that root redirect is served again.

## Root Cause
5chan v0.8.5 changed the surrounding normalization-script comment, so the existing CLI regex no longer removed the script. Behind the daemon, that script can navigate to `/#...`, which targets the Express root instead of the auth-key web UI route.

## Validation
- `npm run build`
- `npm run build:test`
- `npm run ci:download-web-uis`
- `npx vitest run --config config/vitest.config.ts test/cli/daemon.test.ts -t "5chan webui does not contain the root hash redirect script"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to HTML preprocessing and a CLI test; no auth, RPC, or data-path behavior changes.
> 
> **Overview**
> Fixes **5chan** being served behind the daemon with an inline **root hash redirect** still present after a web UI update changed the script’s comment text, so the old strip regex no longer matched.
> 
> `daemon-server.ts` now removes the whole `<script>` block by matching the actual `window.location.replace('/#' + pathname + search)` call instead of the obsolete “Redirect non-hash URLs” comment. The daemon web UI test was updated to assert that redirect snippet is absent from served HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b53fc4f5ed3365ae2fb9573716db0fc1ccdf4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL redirect handling in the web UI daemon to use more precise script pattern matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-cli/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->