### PR TITLE
fix(daemon-state): detect PID reuse so stale state files aren't treated as live daemons

### DIFF
--- a/src/common-utils/daemon-state.ts
+++ b/src/common-utils/daemon-state.ts
@@ -1,6 +1,10 @@
 import defaults from "./defaults.js";
 import path from "path";
 import fs from "fs/promises";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 const DAEMON_STATES_DIR = path.join(defaults.PKC_DATA_PATH, ".daemon_states");
 
@@ -9,14 +13,58 @@ export interface DaemonState {
     startedAt: string;
     argv: string[];
     pkcRpcUrl: string;
+    /** OS-reported process start time, used to detect PID reuse. Absent in legacy state files. */
+    procStartTime?: string;
 }
 
 function stateFilePath(pid: number): string {
     return path.join(DAEMON_STATES_DIR, `${pid}-daemon.state`);
 }
 
+/**
+ * OS-reported start time of a process, used as an identity token: if a state file's PID
+ * was reused by an unrelated process, its start time won't match the recorded one.
+ * Linux: starttime (field 22) of /proc/<pid>/stat, in clock ticks since boot.
+ * Other unix: `ps -o lstart=` output. Returns undefined when it can't be determined.
+ */
+async function getProcessStartTime(pid: number): Promise<string | undefined> {
+    try {
+        const stat = await fs.readFile(`/proc/${pid}/stat`, "utf-8");
+        // comm (field 2) may contain spaces/parens — real fields resume after the last ')'
+        const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+        return fields[19]; // field 22 (starttime), offset by the 3 fields before the split
+    } catch {
+        try {
+            const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "lstart="]);
+            return stdout.trim() || undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+/** Full command line of a process, or undefined when it can't be determined. */
+async function getProcessCommandLine(pid: number): Promise<string | undefined> {
+    try {
+        // An empty /proc cmdline is meaningful (kernel thread — not a daemon), so keep it
+        const raw = await fs.readFile(`/proc/${pid}/cmdline`, "utf-8");
+        return raw.split("\0").join(" ").trim();
+    } catch {
+        try {
+            const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "args="]);
+            return stdout.trim() || undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
 /** Write a daemon state file atomically (write to .tmp then rename). */
 export async function writeDaemonState(state: DaemonState): Promise<void> {
+    if (state.procStartTime === undefined) {
+        const procStartTime = await getProcessStartTime(state.pid);
+        if (procStartTime !== undefined) state = { ...state, procStartTime };
+    }
     await fs.mkdir(DAEMON_STATES_DIR, { recursive: true });
     const dest = stateFilePath(state.pid);
     const tmp = dest + ".tmp";
@@ -67,22 +115,36 @@ function isPidAlive(pid: number): boolean {
     }
 }
 
-/** Delete state files for dead PIDs from disk. */
-export async function pruneStaleStates(): Promise<void> {
-    const states = await readAllDaemonStates();
-    for (const state of states) {
-        if (!isPidAlive(state.pid)) {
-            await deleteDaemonState(state.pid);
-        }
+/**
+ * Check whether the daemon that wrote `state` is still the process running under its PID.
+ * A bare liveness check is not enough: a stale state file's PID may have been reused by an
+ * unrelated process (e.g. a state file written inside a Docker container whose PID maps to
+ * a kernel thread on the host — issue #66).
+ */
+async function isDaemonStateAlive(state: DaemonState): Promise<boolean> {
+    if (!isPidAlive(state.pid)) return false;
+    if (state.procStartTime !== undefined) {
+        const current = await getProcessStartTime(state.pid);
+        if (current !== undefined) return current === state.procStartTime; // mismatch — PID was reused
+        return true; // identity undeterminable — fall back to liveness only
     }
+    // Legacy state file without procStartTime — heuristic: the command line must reference bitsocial
+    const cmdline = await getProcessCommandLine(state.pid);
+    if (cmdline === undefined) return true; // identity undeterminable — fall back to liveness only
+    return cmdline.includes("bitsocial");
 }
 
-/** Read all states, delete stale files (dead PIDs) from disk, return only alive ones. */
+/** Delete state files for dead or reused PIDs from disk. */
+export async function pruneStaleStates(): Promise<void> {
+    await getAliveDaemonStates();
+}
+
+/** Read all states, delete stale files (dead or reused PIDs) from disk, return only alive ones. */
 export async function getAliveDaemonStates(): Promise<DaemonState[]> {
     const states = await readAllDaemonStates();
     const alive: DaemonState[] = [];
     for (const state of states) {
-        if (isPidAlive(state.pid)) {
+        if (await isDaemonStateAlive(state)) {
             alive.push(state);
         } else {
             await deleteDaemonState(state.pid);

--- a/test/common-utils/daemon-state.test.ts
+++ b/test/common-utils/daemon-state.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
+import { spawn, type ChildProcess } from "child_process";
+import { once } from "events";
 import { directory as randomDirectory } from "tempy";
+import defaults from "../../dist/common-utils/defaults.js";
 
 // We test the functions by importing them, but they use a hardcoded DAEMON_STATES_DIR.
 // To isolate tests, we test the logic directly with a custom dir via the module internals.
@@ -110,6 +113,83 @@ describe("daemon-state", () => {
 
             const alive = await getAliveDaemonStates();
             expect(alive.find((s) => s.pid === myPid)).toBeDefined();
+        });
+    });
+
+    // Regression test for https://github.com/bitsocialnet/bitsocial-cli/issues/66
+    // A daemon running inside a Docker container (PID 8 in the container's namespace) wrote its
+    // state file into the bind-mounted data dir. The container died without graceful shutdown,
+    // and on the host PID 8 belongs to a kernel thread — an alive but unrelated process. The
+    // bare `process.kill(pid, 0)` liveness check passed, so `update install` SIGINT'd the
+    // unrelated process and restarted the daemon twice on the same port.
+    describe("getAliveDaemonStates — PID reused by an unrelated process", () => {
+        const DAEMON_STATES_DIR = path.join(defaults.PKC_DATA_PATH, ".daemon_states");
+        let child: ChildProcess | undefined;
+
+        afterEach(() => {
+            child?.kill("SIGKILL");
+            child = undefined;
+        });
+
+        it("should prune a stale state file whose PID now belongs to a process that is not a bitsocial daemon", async () => {
+            // Stand-in for the kernel thread: an alive process that is not a bitsocial daemon
+            // and did not write the state file. Wait for 'spawn' so the child has exec'd and
+            // /proc/<pid>/cmdline shows `sleep`, not the forked copy of this test process.
+            child = spawn("sleep", ["120"]);
+            await once(child, "spawn");
+            const reusedPid = child.pid;
+            expect(reusedPid).toBeDefined();
+            createdPids.push(reusedPid!);
+
+            // Write the state file raw, byte-for-byte like the dead daemon left it on prod
+            // (legacy format — written by an old CLI version, before any identity fields).
+            await fs.mkdir(DAEMON_STATES_DIR, { recursive: true });
+            await fs.writeFile(
+                path.join(DAEMON_STATES_DIR, `${reusedPid}-daemon.state`),
+                JSON.stringify({ pid: reusedPid, startedAt: "2026-05-21T04:01:53.773Z", argv: [], pkcRpcUrl: "ws://localhost:9138/" }, null, 2)
+            );
+
+            const alive = await getAliveDaemonStates();
+            expect(alive.find((s) => s.pid === reusedPid)).toBeUndefined();
+
+            // The stale file must also be deleted from disk
+            const all = await readAllDaemonStates();
+            expect(all.find((s) => s.pid === reusedPid)).toBeUndefined();
+        });
+
+        it("should prune a state file whose recorded procStartTime does not match the process now under that PID", async () => {
+            const myPid = process.pid;
+            createdPids.push(myPid);
+
+            // Alive PID, but the recorded start time belongs to a process that no longer exists
+            await fs.mkdir(DAEMON_STATES_DIR, { recursive: true });
+            await fs.writeFile(
+                path.join(DAEMON_STATES_DIR, `${myPid}-daemon.state`),
+                JSON.stringify({ pid: myPid, startedAt: new Date().toISOString(), argv: [], pkcRpcUrl: "ws://localhost:9138/", procStartTime: "0" }, null, 2)
+            );
+
+            const alive = await getAliveDaemonStates();
+            expect(alive.find((s) => s.pid === myPid)).toBeUndefined();
+        });
+
+        it("should keep a legacy state file (no procStartTime) when the PID is a real bitsocial daemon process", async () => {
+            // Stand-in for a daemon started by an old CLI version: an alive process whose
+            // command line references bitsocial. The compound command (`; sleep 0`) stops bash
+            // from exec-replacing itself with `sleep`, which would drop the marker from cmdline.
+            child = spawn("bash", ["-c", "sleep 120; sleep 0", "bitsocial-daemon-legacy-test"]);
+            await once(child, "spawn");
+            const daemonPid = child.pid;
+            expect(daemonPid).toBeDefined();
+            createdPids.push(daemonPid!);
+
+            await fs.mkdir(DAEMON_STATES_DIR, { recursive: true });
+            await fs.writeFile(
+                path.join(DAEMON_STATES_DIR, `${daemonPid}-daemon.state`),
+                JSON.stringify({ pid: daemonPid, startedAt: new Date().toISOString(), argv: [], pkcRpcUrl: "ws://localhost:9138/" }, null, 2)
+            );
+
+            const alive = await getAliveDaemonStates();
+            expect(alive.find((s) => s.pid === daemonPid)).toBeDefined();
         });
     });
 


### PR DESCRIPTION
Closes #66

## Bug

`isPidAlive()` in `src/common-utils/daemon-state.ts` only checked `process.kill(pid, 0)`. A PID being alive does not prove the process is the bitsocial daemon that wrote the state file (classic stale-pidfile / PID-reuse hazard).

Observed in the wild: a daemon running inside a Docker container (PID 8 in the container's PID namespace) wrote its state file into the bind-mounted data dir. The container died without graceful shutdown; on the host, PID 8 is a kernel thread — alive but unrelated. `bitsocial update install` then:

1. Sent SIGINT to the unrelated process (on a different day this could be any innocent process)
2. Restarted **2** daemons with identical args on the same port; the second died with EADDRINUSE
3. Falsely reported "Daemon started" for the second spawn because `waitUntilUsed` saw the first daemon's port

## Fix

Two layers in `daemon-state.ts`:

1. **New state files** record the OS-reported process start time (`procStartTime`: `/proc/<pid>/stat` field 22 on Linux, `ps -o lstart=` fallback elsewhere). Aliveness checks compare it — a reused PID has a different start time, so the state is pruned.
2. **Legacy state files** (no `procStartTime`) fall back to requiring the process command line to reference `bitsocial`. Kernel threads have an empty cmdline, so the original failure case is correctly pruned. If identity can't be determined at all, behavior falls back to the old liveness-only check (fail-safe: never treats a real running daemon as dead).

## Tests

The bug was reproduced in a regression test **before** fixing (failed on unfixed code):

- prune a legacy state file whose PID now belongs to an alive but unrelated process (byte-for-byte the prod scenario, with `sleep` standing in for the kernel thread)
- prune a state file whose recorded `procStartTime` doesn't match the process now under that PID
- keep a legacy state file whose PID is a genuine bitsocial-daemon-like process (no false pruning on upgrade from older CLI versions)

Spawn-based tests `await once(child, "spawn")` and use a compound bash command to avoid the fork/exec race and bash's exec-optimization (caught as a flake in a full-suite run).

Full suite: 244 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon state detection to reliably identify stale daemon processes and prevent confusion from OS process ID reuse.
  * Enhanced cleanup of obsolete daemon state files with support for both current and legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->