### PR TITLE
feat(challenge): npm-style commands — idempotent install, npm-like output and aliases

### DIFF
--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -305,12 +305,16 @@ export async function verifyNativeModuleAbi(challengeDir: string): Promise<void>
     }
 }
 
-export async function loadChallengesIntoPKC(dataPath?: string): Promise<string[]> {
+export function formatChallengeNameVersion(challenge: Pick<InstalledChallenge, "name" | "version">): string {
+    return challenge.version && challenge.version !== "unknown" ? `${challenge.name}@${challenge.version}` : challenge.name;
+}
+
+export async function loadChallengesIntoPKC(dataPath?: string): Promise<InstalledChallenge[]> {
     const challenges = await listInstalledChallenges(dataPath);
     if (challenges.length === 0) return [];
 
     const PKC = await import("@pkcprotocol/pkc-js");
-    const loadedNames: string[] = [];
+    const loaded: InstalledChallenge[] = [];
 
     for (const challenge of challenges) {
         try {
@@ -321,11 +325,11 @@ export async function loadChallengesIntoPKC(dataPath?: string): Promise<string[]
             const imported = await import(pathToFileURL(entryPath).href);
             const factory = imported.default || imported;
             (PKC.default as any).challenges[challenge.name] = factory;
-            loadedNames.push(challenge.name);
+            loaded.push(challenge);
         } catch (err) {
             console.error(`Failed to load challenge "${challenge.name}":`, err);
         }
     }
 
-    return loadedNames;
+    return loaded;
 }

--- a/src/cli/commands/challenge/install.ts
+++ b/src/cli/commands/challenge/install.ts
@@ -16,6 +16,8 @@ import {
 export default class Install extends Command {
     static override description = "Install a challenge package (npm package name, git URL, tarball URL, or local path)";
 
+    static override aliases = ["challenge:i", "challenge:add"];
+
     static override args = {
         package: Args.string({
             description: "Package specifier — anything npm can install (name, name@version, git URL, tarball URL, local path)",
@@ -39,10 +41,9 @@ export default class Install extends Command {
     ];
 
     async run(): Promise<void> {
+        const startTime = Date.now();
         const { args, flags } = await this.parse(Install);
         const dataPath = flags["pkcOptions.dataPath"] || defaults.PKC_DATA_PATH;
-
-        this.log("Installing challenge package — this may take a few minutes...");
 
         // 1. Check npm is available
         await ensureNpmAvailable();
@@ -87,7 +88,18 @@ export default class Install extends Command {
             // 5. Read package info
             const pkg = await readChallengePackageJson(pkgDir);
 
-            // 6. Check not already installed
+            // 6. Run npm install in the temp dir, so a failed install never
+            //    touches an existing working installation of the same package
+            process.stderr.write(`[challenge-install] starting npm install in ${pkgDir}\n`);
+            await runNpmInstall(pkgDir);
+            process.stderr.write("[challenge-install] npm install completed\n");
+
+            // 7. Verify native modules are ABI-compatible (still in the temp dir,
+            //    so failure needs no rollback — the temp dir is cleaned up below)
+            await verifyNativeModuleAbi(pkgDir);
+
+            // 8. Swap the verified package into the challenges dir, replacing any
+            //    existing installation (idempotent, like npm install)
             const challengesDir = await ensureChallengesDir(dataPath);
             const destDir = challengeNameToDir(challengesDir, pkg.name);
             let alreadyExists = true;
@@ -96,53 +108,38 @@ export default class Install extends Command {
             } catch {
                 alreadyExists = false;
             }
-            if (alreadyExists) {
-                this.error(`Challenge "${pkg.name}" is already installed. Remove it first with: bitsocial challenge remove ${pkg.name}`);
-            }
 
-            // 7. Move to challenges dir
+            // Move any existing install aside (same filesystem — tmpDir lives under
+            // dataPath) so it can be restored if the final rename fails
+            const backupDir = path.join(tmpDir, "previous-install");
+            if (alreadyExists) await fs.rename(destDir, backupDir);
+
             if (pkg.name.startsWith("@")) {
                 // Ensure scope dir exists for scoped packages
                 const scopeDir = path.dirname(destDir);
                 await fs.mkdir(scopeDir, { recursive: true });
             }
-            await fs.rename(pkgDir, destDir);
-
-            // 8. Run npm install
-            process.stderr.write(`[challenge-install] starting npm install in ${destDir}\n`);
-            await runNpmInstall(destDir);
-            process.stderr.write("[challenge-install] npm install completed\n");
-
-            // 9. Verify native modules are ABI-compatible
             try {
-                await verifyNativeModuleAbi(destDir);
+                await fs.rename(pkgDir, destDir);
             } catch (err) {
-                // Roll back the installation on ABI mismatch
-                await fs.rm(destDir, { recursive: true, force: true });
-                if (pkg.name.startsWith("@")) {
-                    const scopeDir = path.dirname(destDir);
-                    try {
-                        const entries = await fs.readdir(scopeDir);
-                        if (entries.length === 0) await fs.rmdir(scopeDir);
-                    } catch {
-                        // ignore
-                    }
-                }
-                this.error(err instanceof Error ? err.message : String(err));
+                // Restore the previous installation before surfacing the error
+                if (alreadyExists) await fs.rename(backupDir, destDir);
+                throw err;
             }
 
-            // 10. Print success
+            // 9. Print success (npm-style)
             const version = pkg.version ? `@${pkg.version}` : "";
-            this.log(`Installed challenge '${pkg.name}${version}'`);
+            const elapsedSeconds = Math.max(1, Math.round((Date.now() - startTime) / 1000));
+            this.log(`${alreadyExists ? "changed" : "added"} ${pkg.name}${version} in ${elapsedSeconds}s`);
 
-            // 11. Best-effort reload via daemon
+            // 10. Best-effort reload via daemon
             try {
                 await fetch("http://localhost:9138/api/challenges/reload", { method: "POST" });
             } catch {
                 // daemon not running, that's fine
             }
         } finally {
-            // 12. Clean up temp dir
+            // 11. Clean up temp dir (includes the previous-install backup, if any)
             await fs.rm(tmpDir, { recursive: true, force: true });
         }
     }

--- a/src/cli/commands/challenge/list.ts
+++ b/src/cli/commands/challenge/list.ts
@@ -1,11 +1,13 @@
 import { Flags, Command } from "@oclif/core";
 import { EOL } from "os";
-import { printTable } from "@oclif/table";
+import path from "path";
 import defaults from "../../../common-utils/defaults.js";
-import { listInstalledChallenges } from "../../../challenge-packages/challenge-utils.js";
+import { getChallengesDir, listInstalledChallenges, formatChallengeNameVersion } from "../../../challenge-packages/challenge-utils.js";
 
 export default class List extends Command {
     static override description = "List installed challenge packages";
+
+    static override aliases = ["challenge:ls"];
 
     static override flags = {
         quiet: Flags.boolean({ char: "q", summary: "Only display challenge names" }),
@@ -21,7 +23,8 @@ export default class List extends Command {
         const { flags } = await this.parse(List);
         const dataPath = flags["pkcOptions.dataPath"] || defaults.PKC_DATA_PATH;
 
-        const challenges = await listInstalledChallenges(dataPath);
+        // Sort alphabetically like npm ls (readdir order is filesystem-dependent)
+        const challenges = (await listInstalledChallenges(dataPath)).sort((a, b) => a.name.localeCompare(b.name));
 
         if (challenges.length === 0) {
             this.log("No challenge packages installed.");
@@ -31,12 +34,11 @@ export default class List extends Command {
         if (flags.quiet) {
             this.log(challenges.map((c) => c.name).join(EOL));
         } else {
-            printTable({
-                data: challenges.map((c) => ({
-                    name: c.name,
-                    version: c.version,
-                    description: c.description
-                }))
+            // npm-ls-style tree: challenges dir header, then name@version entries
+            this.log(path.resolve(getChallengesDir(dataPath)));
+            challenges.forEach((c, i) => {
+                const branch = i === challenges.length - 1 ? "└── " : "├── ";
+                this.log(`${branch}${formatChallengeNameVersion(c)}`);
             });
         }
     }

--- a/src/cli/commands/challenge/remove.ts
+++ b/src/cli/commands/challenge/remove.ts
@@ -2,10 +2,12 @@ import { Args, Flags, Command } from "@oclif/core";
 import fs from "fs/promises";
 import path from "path";
 import defaults from "../../../common-utils/defaults.js";
-import { getChallengesDir, challengeNameToDir } from "../../../challenge-packages/challenge-utils.js";
+import { getChallengesDir, challengeNameToDir, readChallengePackageJson } from "../../../challenge-packages/challenge-utils.js";
 
 export default class Remove extends Command {
     static override description = "Remove an installed challenge package";
+
+    static override aliases = ["challenge:uninstall", "challenge:rm", "challenge:un"];
 
     static override args = {
         name: Args.string({
@@ -40,6 +42,15 @@ export default class Remove extends Command {
             this.error(`Challenge "${args.name}" is not installed.`);
         }
 
+        // Read the installed version for the success message (best-effort)
+        let version = "";
+        try {
+            const pkg = await readChallengePackageJson(challengeDir);
+            if (pkg.version) version = `@${pkg.version}`;
+        } catch {
+            // unreadable package.json — report the name only
+        }
+
         // Remove the challenge directory
         await fs.rm(challengeDir, { recursive: true, force: true });
 
@@ -56,7 +67,7 @@ export default class Remove extends Command {
             }
         }
 
-        this.log(`Removed challenge '${args.name}'`);
+        this.log(`removed ${args.name}${version}`);
 
         // Best-effort reload via daemon
         try {

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -16,7 +16,7 @@ import {
 import type { PKCLoggerType } from "../../util.js";
 import { startDaemonServer } from "../../webui/daemon-server.js";
 import { printBanner } from "../ascii-banner.js";
-import { loadChallengesIntoPKC } from "../../challenge-packages/challenge-utils.js";
+import { loadChallengesIntoPKC, formatChallengeNameVersion } from "../../challenge-packages/challenge-utils.js";
 import { migrateDataDirectory } from "../../common-utils/data-migration.js";
 import { createBsoResolvers, DEFAULT_PROVIDERS } from "../../common-utils/resolvers.js";
 import { pruneStaleStates, writeDaemonState, deleteDaemonState } from "../../common-utils/daemon-state.js";
@@ -453,7 +453,8 @@ export default class Daemon extends Command {
 
                 // Load installed challenge packages before starting the RPC server
                 const loadedChallenges = await loadChallengesIntoPKC(mergedPkcOptions.dataPath);
-                if (loadedChallenges.length > 0) console.log(`Loaded challenge packages: ${loadedChallenges.join(", ")}`);
+                if (loadedChallenges.length > 0)
+                    console.log(`Loaded challenge packages: ${loadedChallenges.map(formatChallengeNameVersion).join(", ")}`);
 
                 daemonServer = await startDaemonServer(pkcRpcUrl, ipfsGatewayEndpoint, mergedPkcOptions, {
                     allowPrivateKeyExport: flags.allowPrivateKeyExport

--- a/src/webui/daemon-server.ts
+++ b/src/webui/daemon-server.ts
@@ -7,7 +7,7 @@ import fs from "fs/promises";
 import { PKCLogger } from "../util.js";
 import { randomBytes } from "crypto";
 import express from "express";
-import { loadChallengesIntoPKC } from "../challenge-packages/challenge-utils.js";
+import { loadChallengesIntoPKC, formatChallengeNameVersion } from "../challenge-packages/challenge-utils.js";
 
 const rootHashRedirectScriptPattern =
     /<script\b[^>]*>(?:(?!<\/script>)[\s\S])*?window\.location\.replace\(["']\/#["']\s*\+\s*window\.location\.pathname\s*\+\s*window\.location\.search\);(?:(?!<\/script>)[\s\S])*?<\/script>/;
@@ -164,7 +164,7 @@ export async function startDaemonServer(
     // Challenge reload endpoints
     const handleChallengeReload = async (_req: express.Request, res: express.Response) => {
         try {
-            const loadedNames = await loadChallengesIntoPKC(pkcOptions.dataPath);
+            const loadedChallenges = await loadChallengesIntoPKC(pkcOptions.dataPath);
             // Notify all connected RPC clients about the updated challenges
             const onSettingsChange = (rpcServer as any)._onSettingsChange;
             if (onSettingsChange) {
@@ -177,7 +177,7 @@ export async function startDaemonServer(
                     }
                 }
             }
-            res.json({ ok: true, challenges: loadedNames });
+            res.json({ ok: true, challenges: loadedChallenges.map(formatChallengeNameVersion) });
         } catch (err) {
             log.error("Failed to reload challenges", err);
             res.status(500).json({ ok: false, error: String(err) });

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -165,7 +165,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
 
         const installResult = await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
         expect(installResult.exitCode).toBe(0);
-        expect(installResult.stdout).toContain("Installed challenge 'test-challenge@1.0.0'");
+        expect(installResult.stdout).toContain("added test-challenge@1.0.0 in");
 
         // Start daemon — it handles kubo, RPC, and webui internally
         daemonProcess = await startPkcDaemon(
@@ -221,7 +221,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
         });
 
         it("daemon loads installed challenge on startup", () => {
-            expect(daemonProcess?.capturedStdout).toContain("Loaded challenge packages: test-challenge");
+            expect(daemonProcess?.capturedStdout).toContain("Loaded challenge packages: test-challenge@1.0.0");
         });
 
         it("correct answer passes challenge verification", { timeout: 120_000 }, async () => {
@@ -309,14 +309,14 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
             // Install while daemon is running
             const installResult = await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
             expect(installResult.exitCode).toBe(0);
-            expect(installResult.stdout).toContain("Installed challenge 'test-challenge-v2@1.0.0'");
+            expect(installResult.stdout).toContain("added test-challenge-v2@1.0.0 in");
 
             // Trigger reload
             const reloadRes = await fetch(`http://localhost:${RPC_PORT}/api/challenges/reload`, { method: "POST" });
             expect(reloadRes.status).toBe(200);
             const reloadBody = (await reloadRes.json()) as { ok: boolean; challenges: string[] };
             expect(reloadBody.ok).toBe(true);
-            expect(reloadBody.challenges).toContain("test-challenge-v2");
+            expect(reloadBody.challenges).toContain("test-challenge-v2@1.0.0");
 
             // Create a community using the hot-reloaded challenge
             const sub = await pkc.createCommunity();

--- a/test/cli/challenge.test.ts
+++ b/test/cli/challenge.test.ts
@@ -89,7 +89,7 @@ describe("bitsocial challenge install", () => {
         const dataPath = randomDirectory();
         const result = await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain("Installed challenge 'test-challenge@1.0.0'");
+        expect(result.stdout).toContain("added test-challenge@1.0.0 in");
 
         // Verify directory structure
         const challengeDir = path.join(dataPath, "challenges", "test-challenge");
@@ -101,15 +101,53 @@ describe("bitsocial challenge install", () => {
         expect(pkg.name).toBe("test-challenge");
     });
 
-    it("errors when already installed", async () => {
+    it("reinstall replaces an existing installation (idempotent, like npm)", async () => {
         const dataPath = randomDirectory();
+        const srcDir = path.join(randomDirectory(), "reinstall-challenge");
+        await createMinimalChallengeDir(srcDir, "reinstall-challenge", { version: "1.0.0" });
+
         // Install once
-        await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
-        // Try again
-        const result = await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
-        expect(result.exitCode).not.toBe(0);
-        const combined = `${result.stdout}\n${result.stderr}`;
-        expect(combined).toContain("already installed");
+        const first = await runBitsocialChallenge(["install", srcDir, "--pkcOptions.dataPath", dataPath]);
+        expect(first.exitCode).toBe(0);
+        expect(first.stdout).toContain("added reinstall-challenge@1.0.0 in");
+
+        // Bump the version and install again — must replace, not error
+        const pkgPath = path.join(srcDir, "package.json");
+        const pkg = JSON.parse(await fsPromise.readFile(pkgPath, "utf-8"));
+        pkg.version = "1.1.0";
+        await fsPromise.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
+
+        const second = await runBitsocialChallenge(["install", srcDir, "--pkcOptions.dataPath", dataPath]);
+        expect(second.exitCode, `reinstall failed with stderr:\n${second.stderr}`).toBe(0);
+        expect(second.stdout).toContain("changed reinstall-challenge@1.1.0 in");
+
+        // Installed package.json must reflect the new version
+        const installedPkg = JSON.parse(
+            await fsPromise.readFile(path.join(dataPath, "challenges", "reinstall-challenge", "package.json"), "utf-8")
+        );
+        expect(installedPkg.version).toBe("1.1.0");
+    });
+
+    it("reinstall with the same version still replaces the content", async () => {
+        const dataPath = randomDirectory();
+        const srcDir = path.join(randomDirectory(), "same-version-challenge");
+        await createMinimalChallengeDir(srcDir, "same-version-challenge", { version: "1.0.0" });
+
+        const first = await runBitsocialChallenge(["install", srcDir, "--pkcOptions.dataPath", dataPath]);
+        expect(first.exitCode).toBe(0);
+
+        // Change index.js content without bumping the version (e.g. local/git installs)
+        const newIndexContent = `export default function() { return { type: 'text/plain', challenge: '2+2', getChallenge: async () => ({ challenge: '2+2', type: 'text/plain', verify: async (answer) => ({ success: answer === '4' }) }) }; };\n`;
+        await fsPromise.writeFile(path.join(srcDir, "index.js"), newIndexContent);
+
+        const second = await runBitsocialChallenge(["install", srcDir, "--pkcOptions.dataPath", dataPath]);
+        expect(second.exitCode, `reinstall failed with stderr:\n${second.stderr}`).toBe(0);
+        expect(second.stdout).toContain("changed same-version-challenge@1.0.0 in");
+
+        const installedIndex = await fsPromise.readFile(
+            path.join(dataPath, "challenges", "same-version-challenge", "index.js"), "utf-8"
+        );
+        expect(installedIndex).toBe(newIndexContent);
     });
 
     it("installs successfully when devDependencies have unresolvable versions", async () => {
@@ -232,7 +270,7 @@ describe("bitsocial challenge install (scoped package)", () => {
         const dataPath = randomDirectory();
         const result = await runBitsocialChallenge(["install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]);
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain("Installed challenge '@test-scope/my-challenge@2.0.0'");
+        expect(result.stdout).toContain("added @test-scope/my-challenge@2.0.0 in");
 
         // Verify nested directory structure @scope/name
         const challengeDir = path.join(dataPath, "challenges", "@test-scope", "my-challenge");
@@ -249,7 +287,7 @@ describe("bitsocial challenge list", () => {
         expect(result.stdout).toContain("No challenge packages installed");
     });
 
-    it("shows installed challenges in table", async () => {
+    it("shows installed challenges as an npm-ls-style tree", async () => {
         const dataPath = randomDirectory();
         // Manually create a challenge dir
         const challengeDir = path.join(dataPath, "challenges", "test-challenge");
@@ -260,8 +298,33 @@ describe("bitsocial challenge list", () => {
 
         const result = await runBitsocialChallenge(["list", "--pkcOptions.dataPath", dataPath]);
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain("test-challenge");
-        expect(result.stdout).toContain("1.0.0");
+        // Header line is the challenges dir, entries are name@version
+        expect(result.stdout).toContain(path.join(dataPath, "challenges"));
+        expect(result.stdout).toContain("└── test-challenge@1.0.0");
+    });
+
+    it("sorts tree entries alphabetically with ├──/└── branches", async () => {
+        const dataPath = randomDirectory();
+        await createMinimalChallengeDir(path.join(dataPath, "challenges", "test-challenge"), "test-challenge", {
+            version: "1.0.0"
+        });
+        await createMinimalChallengeDir(
+            path.join(dataPath, "challenges", "@test-scope", "my-challenge"),
+            "@test-scope/my-challenge",
+            { version: "2.0.0" }
+        );
+
+        const result = await runBitsocialChallenge(["list", "--pkcOptions.dataPath", dataPath]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("├── @test-scope/my-challenge@2.0.0");
+        expect(result.stdout).toContain("└── test-challenge@1.0.0");
+    });
+
+    it("works via the ls alias", async () => {
+        const dataPath = randomDirectory();
+        const result = await runBitsocialChallenge(["ls", "--pkcOptions.dataPath", dataPath]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("No challenge packages installed");
     });
 
     it("shows names only with -q", async () => {
@@ -286,7 +349,7 @@ describe("bitsocial challenge remove", () => {
 
         const result = await runBitsocialChallenge(["remove", "test-challenge", "--pkcOptions.dataPath", dataPath]);
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain("Removed challenge 'test-challenge'");
+        expect(result.stdout).toContain("removed test-challenge@1.0.0");
 
         // Verify it's gone
         await expect(fsPromise.access(challengeDir)).rejects.toThrow();
@@ -304,7 +367,7 @@ describe("bitsocial challenge remove", () => {
             dataPath
         ]);
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain("Removed challenge '@test-scope/my-challenge'");
+        expect(result.stdout).toContain("removed @test-scope/my-challenge@1.0.0");
 
         // Verify both the challenge dir and scope dir are gone
         const scopeDir = path.join(dataPath, "challenges", "@test-scope");
@@ -317,5 +380,16 @@ describe("bitsocial challenge remove", () => {
         expect(result.exitCode).not.toBe(0);
         const combined = `${result.stdout}\n${result.stderr}`;
         expect(combined).toContain("not installed");
+    });
+
+    it("works via the uninstall alias", async () => {
+        const dataPath = randomDirectory();
+        const challengeDir = path.join(dataPath, "challenges", "test-challenge");
+        await createMinimalChallengeDir(challengeDir, "test-challenge", { version: "1.0.0" });
+
+        const result = await runBitsocialChallenge(["uninstall", "test-challenge", "--pkcOptions.dataPath", dataPath]);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("removed test-challenge@1.0.0");
+        await expect(fsPromise.access(challengeDir)).rejects.toThrow();
     });
 });

--- a/test/cli/command-completion-time.test.ts
+++ b/test/cli/command-completion-time.test.ts
@@ -242,7 +242,7 @@ describe("challenge commands complete within 10s", () => {
             ["challenge", "install", challengeSrcDir, "--pkcOptions.dataPath", dataPath]
         );
         expect(result.exitCode, `stderr: ${result.stderr}\nstdout: ${result.stdout}`).toBe(0);
-        expect(result.stdout).toContain("Installed challenge 'test-challenge@1.0.0'");
+        expect(result.stdout).toContain("added test-challenge@1.0.0 in");
     });
 
     it("challenge list (after install) completes within 10s", { timeout: 10_000 }, async () => {
@@ -258,7 +258,7 @@ describe("challenge commands complete within 10s", () => {
             ["challenge", "remove", "test-challenge", "--pkcOptions.dataPath", dataPath]
         );
         expect(result.exitCode, `stderr: ${result.stderr}\nstdout: ${result.stdout}`).toBe(0);
-        expect(result.stdout).toContain("Removed challenge 'test-challenge'");
+        expect(result.stdout).toContain("removed test-challenge@1.0.0");
     });
 
     it("challenge list (after remove) completes within 10s", { timeout: 10_000 }, async () => {

--- a/test/cli/mintpass-integration.test.ts
+++ b/test/cli/mintpass-integration.test.ts
@@ -127,7 +127,7 @@ describe.skipIf(process.platform === "win32")("@bitsocial/mintpass-challenge int
         // Install the real @bitsocial/mintpass-challenge package from npm
         const installResult = await runBitsocialChallenge(["install", "@bitsocial/mintpass-challenge", "--pkcOptions.dataPath", dataPath], undefined, 420_000);
         expect(installResult.exitCode).toBe(0);
-        expect(installResult.stdout).toContain("Installed challenge '@bitsocial/mintpass-challenge");
+        expect(installResult.stdout).toContain("added @bitsocial/mintpass-challenge");
 
         // Start daemon — it handles kubo, RPC, and webui internally
         daemonProcess = await startPkcDaemon(["--pkcOptions.dataPath", dataPath, "--pkcRpcUrl", rpcWsUrl], {
@@ -172,7 +172,8 @@ describe.skipIf(process.platform === "win32")("@bitsocial/mintpass-challenge int
         expect(reloadRes.status).toBe(200);
         const reloadBody = (await reloadRes.json()) as { ok: boolean; challenges: string[] };
         expect(reloadBody.ok).toBe(true);
-        expect(reloadBody.challenges).toContain("@bitsocial/mintpass-challenge");
+        // Entries are name@version strings; the installed version follows npm's latest
+        expect(reloadBody.challenges.some((c) => c.startsWith("@bitsocial/mintpass-challenge@"))).toBe(true);
     });
 
     it("publish without wallet fails with wallet-not-defined error", { timeout: 120_000 }, async () => {


### PR DESCRIPTION
Closes #68

## What

Makes the `bitsocial challenge` command suite behave like npm:

- **Idempotent install** — `challenge install` replaces an existing installation instead of erroring with "Remove it first". The new package is npm-installed and ABI-verified in a temp dir *first*, then atomically swapped into `challenges/`; the previous install is renamed aside and restored if the swap fails, so a failed install never breaks a working one. Always replaces, even at the same version (git/local installs can differ in content).
- **npm-style messages** — `added <name>@<ver> in <N>s` (fresh) / `changed <name>@<ver> in <N>s` (replaced) / `removed <name>@<ver>`. Remove still errors on not-installed packages (kept deliberately; npm's silent no-op hides typos).
- **npm-style aliases** — `challenge i`/`add`, `challenge uninstall`/`rm`/`un`, `challenge ls`.
- **npm-ls-style list** — alphabetically sorted tree (challenges dir header + `├── name@version`) instead of the table; `-q` unchanged.
- **Versions in daemon log** — `Loaded challenge packages: @bitsocial/mintpass-challenge@2.0.0, ...`; `loadChallengesIntoPKC()` now returns `InstalledChallenge[]` and the `/api/challenges/reload` response reports `name@version` strings.

## Tests

- New: reinstall-replaces, same-version-reinstall-replaces-content, `ls` alias, `uninstall` alias, sorted-tree-with-branches
- Updated assertions in `challenge.test.ts`, `challenge-integration.test.ts`, `command-completion-time.test.ts`, `mintpass-integration.test.ts`
- Full `npm run test:cli`: 30/30 files, 251 passed, 1 skipped
- Manual smoke: fresh install, same-version reinstall (`changed`, exit 0), aliases, tree output, not-installed error path