### PR TITLE
fix(daemon): eliminate kubo restart races that orphan kubo or hang shutdown

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -537,23 +537,19 @@ export default class Daemon extends Command {
             };
 
             const killKuboProcess = async () => {
-                // Wait for any in-flight start attempt so we kill the kubo it may still spawn.
-                // Both promises settle on all paths (issue #70): keepKuboUpOnce re-checks
-                // mainProcessExited after its awaits, and startKuboNode rejects on every failure.
-                if (keepKuboUpInFlight) {
-                    try {
-                        await keepKuboUpInFlight;
-                    } catch {
-                        /* ignore */
-                    }
-                }
-                if (pendingKuboStart) {
-                    try {
-                        await pendingKuboStart;
-                    } catch {
-                        /* ignore */
-                    }
-                }
+                // Wait (bounded) for any in-flight start attempt so we kill the kubo it may still
+                // spawn. Both promises settle on all failure paths (issue #70), but a spawned kubo
+                // that wedges before "Daemon is ready" without exiting keeps them pending — the
+                // bound ensures shutdown still reaches the SIGINT/SIGKILL flow below, which kills
+                // it via kuboProcess (set in onSpawn) or the liveKuboPids sweep (PR #71 review).
+                const inFlightStarts = [keepKuboUpInFlight, pendingKuboStart]
+                    .filter((promise) => promise !== undefined)
+                    .map((promise) => promise.catch(() => {}));
+                if (inFlightStarts.length > 0)
+                    await Promise.race([
+                        Promise.all(inFlightStarts),
+                        new Promise<void>((resolve) => setTimeout(resolve, 15_000).unref())
+                    ]);
                 if (kuboProcess?.pid && !kuboProcess.killed) {
                     const pid = kuboProcess.pid;
                     log("Attempting to kill kubo process with pid", pid);

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -623,6 +623,52 @@ export default class Daemon extends Command {
                 for (const pid of liveKuboPids) killKuboProcessGroup(pid, "SIGKILL");
             });
 
+            // Persistent signal guard (issue #70): exit-hook registers its SIGINT/SIGTERM handlers
+            // with process.once, so its listener vanishes from the listener list the moment a
+            // signal is dispatched. signal-exit (loaded by @pkcprotocol/proper-lock-file and other
+            // dependencies) re-raises the signal when every remaining listener is its own — which
+            // would kill the process while the async exit hook above is still shutting kubo down.
+            // A persistent non-signal-exit listener keeps that heuristic from ever firing.
+            // A repeated signal force-quits immediately (impatient Ctrl+C): process.exit triggers
+            // the emergency "exit" handler above, which SIGKILLs every live kubo.
+            let terminationSignalCount = 0;
+            for (const signal of ["SIGINT", "SIGTERM"] as const) {
+                process.on(signal, () => {
+                    terminationSignalCount++;
+                    if (terminationSignalCount >= 2) {
+                        log(`Received ${signal} again during shutdown, force-quitting`);
+                        process.exit(signal === "SIGINT" ? 130 : 143);
+                    }
+                });
+            }
+
+            // Test hook (issue #70): simulates a dependency registering a signal-exit handler
+            // AFTER the asyncExitHook above — what @pkcprotocol/proper-lock-file (and the
+            // signal-exit copies under ink/restore-cursor) do at module load. signal-exit
+            // re-raises the signal when every remaining listener belongs to the signal-exit
+            // family (`if (listeners.length === count) { ... process.kill(process.pid, s) }`),
+            // which kills the daemon while the async exit hook is still cleaning up kubo —
+            // exit-hook registers with process.once, so its listener is already gone by then.
+            if (process.env["PKC_CLI_TEST_SIMULATE_LATE_SIGNAL_EXIT"]) {
+                for (const signal of ["SIGINT", "SIGTERM"] as const) {
+                    // Real signal-exit copies only count each other as "family" (via a shared
+                    // global marker); any other listener makes them defer. Identify family by
+                    // source: signal-exit's dispatcher carries the "an exit is coming" comment.
+                    const isSignalExitFamily = (listener: NodeJS.SignalsListener) =>
+                        String(listener).includes("an exit is coming");
+                    const reRaiser = () => {
+                        const onlyFamilyLeft = process
+                            .listeners(signal)
+                            .every((listener) => listener === reRaiser || isSignalExitFamily(listener));
+                        if (onlyFamilyLeft) {
+                            process.removeListener(signal, reRaiser);
+                            process.kill(process.pid, signal);
+                        }
+                    };
+                    process.on(signal, reRaiser);
+                }
+            }
+
             // RPC port was already verified free above (fail-fast); only the kuboRpcClientsOptions branch skips local kubo.
             if (!pkcOptionsFromFlag?.kuboRpcClientsOptions) await keepKuboUp();
             await createOrConnectRpc();

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -345,12 +345,25 @@ export default class Daemon extends Command {
             let pendingKuboStart: Promise<ChildProcessWithoutNullStreams> | undefined;
             // Kubo Node may fail randomly, we need to set a listener so when it exits because of an error we restart it
             let kuboProcess: ChildProcessWithoutNullStreams | undefined;
-            const keepKuboUp = async () => {
+            // Every kubo we've spawned that hasn't exited yet. Exit cleanup kills all of these,
+            // so a kubo that slipped out of kuboProcess tracking still dies with the daemon (issue #70)
+            const liveKuboPids = new Set<number>();
+            const keepKuboUpOnce = async () => {
                 if (mainProcessExited) return;
                 const kuboApiPort = Number(kuboRpcEndpoint.port);
                 if (kuboProcess || pendingKuboStart) return; // already started, no need to intervene
                 const connectHostname = toConnectableHostname(kuboRpcEndpoint.hostname);
                 const isKuboApiPortTaken = await tcpPortUsed.check(kuboApiPort, connectHostname);
+                // Test hook: widens the window between the re-entrancy guard above and the pendingKuboStart
+                // assignment below, so tests can deterministically reproduce concurrent keepKuboUp entries
+                // (issue #70, see test/cli/daemon-kubo-restart-race.test.ts)
+                const portCheckDelayRaw = process.env["PKC_CLI_TEST_KEEPKUBOUP_PORTCHECK_DELAY_MS"];
+                const portCheckDelay = portCheckDelayRaw ? Number(portCheckDelayRaw) : 0;
+                if (Number.isFinite(portCheckDelay) && portCheckDelay > 0)
+                    await new Promise((resolve) => setTimeout(resolve, portCheckDelay));
+                // Re-check after the awaits above: the daemon may have begun shutting down, or another
+                // kubo may have been adopted in the meantime — spawning now would race it (issue #70)
+                if (mainProcessExited || kuboProcess || pendingKuboStart) return;
                 if (isKuboApiPortTaken) {
                     const connectableEndpoint = new URL(kuboRpcEndpoint.toString());
                     connectableEndpoint.hostname = connectHostname;
@@ -378,19 +391,27 @@ export default class Daemon extends Command {
                         }:${kuboApiPort} (configured as ${kuboRpcEndpoint.toString()}) is already in use.`
                     );
                 }
+                let spawnedProcess: ChildProcessWithoutNullStreams | undefined;
                 const startPromise = startKuboNode(kuboRpcEndpoint, ipfsGatewayEndpoint, mergedPkcOptions.dataPath!, (process) => {
+                    spawnedProcess = process;
                     kuboProcess = process;
+                    if (process.pid) {
+                        const pid = process.pid;
+                        liveKuboPids.add(pid);
+                        process.once("exit", () => liveKuboPids.delete(pid));
+                    }
                 });
                 pendingKuboStart = startPromise;
                 let startedProcess: ChildProcessWithoutNullStreams | undefined;
                 try {
                     startedProcess = await startPromise;
                 } catch (error) {
-                    pendingKuboStart = undefined;
-                    if (!mainProcessExited) kuboProcess = undefined;
+                    // Only clear state this attempt owns — it may track another attempt's healthy kubo (issue #70)
+                    if (pendingKuboStart === startPromise) pendingKuboStart = undefined;
+                    if (!mainProcessExited && spawnedProcess && kuboProcess === spawnedProcess) kuboProcess = undefined;
                     throw error;
                 }
-                pendingKuboStart = undefined;
+                if (pendingKuboStart === startPromise) pendingKuboStart = undefined;
                 if (mainProcessExited) {
                     if (startedProcess?.pid && !startedProcess.killed) {
                         // Race condition: Kubo finished starting after mainProcessExited.
@@ -409,7 +430,7 @@ export default class Daemon extends Command {
                             /* best effort */
                         }
                     }
-                    kuboProcess = undefined;
+                    if (kuboProcess === startedProcess) kuboProcess = undefined;
                     return;
                 }
                 kuboProcess = startedProcess;
@@ -421,7 +442,7 @@ export default class Daemon extends Command {
                     // Restart Kubo process because it failed
                     if (!mainProcessExited) {
                         log(`Kubo node with pid (${currentProcess?.pid}) exited. Will attempt to restart it`);
-                        kuboProcess = undefined;
+                        if (kuboProcess === currentProcess) kuboProcess = undefined;
                         try {
                             await keepKuboUp();
                         } catch (error) {
@@ -434,6 +455,20 @@ export default class Daemon extends Command {
                     }
                 };
                 currentProcess.once("exit", onKuboExit);
+            };
+
+            // Single-flight wrapper: keepKuboUp is invoked from independent places (the kubo exit
+            // handler and the watchdog interval). Concurrent callers must share one attempt —
+            // otherwise both can pass keepKuboUpOnce's re-entrancy guard during its awaits and
+            // spawn two kubo processes whose failure handling corrupts shared state (issue #70)
+            let keepKuboUpInFlight: Promise<void> | undefined;
+            const keepKuboUp = () => {
+                if (!keepKuboUpInFlight) {
+                    keepKuboUpInFlight = keepKuboUpOnce().finally(() => {
+                        keepKuboUpInFlight = undefined;
+                    });
+                }
+                return keepKuboUpInFlight;
             };
 
             let startedOwnRpc = false;
@@ -502,6 +537,16 @@ export default class Daemon extends Command {
             };
 
             const killKuboProcess = async () => {
+                // Wait for any in-flight start attempt so we kill the kubo it may still spawn.
+                // Both promises settle on all paths (issue #70): keepKuboUpOnce re-checks
+                // mainProcessExited after its awaits, and startKuboNode rejects on every failure.
+                if (keepKuboUpInFlight) {
+                    try {
+                        await keepKuboUpInFlight;
+                    } catch {
+                        /* ignore */
+                    }
+                }
                 if (pendingKuboStart) {
                     try {
                         await pendingKuboStart;
@@ -535,6 +580,10 @@ export default class Daemon extends Command {
                         kuboProcess = undefined;
                     }
                 }
+                // Defense in depth: SIGKILL any spawned kubo that slipped out of kuboProcess
+                // tracking (e.g. via a state race) so nothing outlives the daemon (issue #70)
+                for (const pid of liveKuboPids) killKuboProcessGroup(pid, "SIGKILL");
+                liveKuboPids.clear();
             };
 
             asyncExitHook(
@@ -569,12 +618,13 @@ export default class Daemon extends Command {
             );
 
             // Emergency cleanup: if the process force-exits (e.g. double Ctrl+C),
-            // synchronously SIGKILL kubo's process group. This is a no-op if
-            // killKuboProcess() already ran (it sets kuboProcess = undefined).
+            // synchronously SIGKILL every live kubo's process group. This is a no-op if
+            // killKuboProcess() already ran (it clears kuboProcess and liveKuboPids).
             process.on("exit", () => {
                 if (kuboProcess?.pid) {
                     killKuboProcessGroup(kuboProcess.pid, "SIGKILL");
                 }
+                for (const pid of liveKuboPids) killKuboProcessGroup(pid, "SIGKILL");
             });
 
             // RPC port was already verified free above (fail-fast); only the kuboRpcClientsOptions branch skips local kubo.

--- a/src/ipfs/startIpfs.ts
+++ b/src/ipfs/startIpfs.ts
@@ -210,54 +210,55 @@ export async function startKuboNode(
     dataPath: string,
     onSpawn?: (process: ChildProcessWithoutNullStreams) => void
 ): Promise<ChildProcessWithoutNullStreams> {
-    return new Promise(async (resolve, reject) => {
-        const log = PKCLogger("bitsocial-cli:ipfs:startKuboNode");
-        const ipfsDataPath = process.env["IPFS_PATH"] || path.join(dataPath, ".bitsocial-cli.ipfs");
-        await fs.promises.mkdir(ipfsDataPath, { recursive: true });
-        const ipfsConfigPath = path.join(ipfsDataPath, "config");
+    // Preparation phase runs as plain awaits so any failure rejects the returned promise.
+    // It must NOT live inside the new Promise() executor below: an async executor swallows
+    // throws as unhandledRejections and the promise never settles, which wedges the daemon's
+    // pendingKuboStart tracking and hangs its shutdown (issue #70).
+    const log = PKCLogger("bitsocial-cli:ipfs:startKuboNode");
+    const ipfsDataPath = process.env["IPFS_PATH"] || path.join(dataPath, ".bitsocial-cli.ipfs");
+    await fs.promises.mkdir(ipfsDataPath, { recursive: true });
+    const ipfsConfigPath = path.join(ipfsDataPath, "config");
 
-        const kuboExePath = await getKuboExePath();
-        const kuboVersion = await getKuboVersion();
-        log(`Using Kubo version: ${kuboVersion}`);
-        log(`IpfsDataPath (${ipfsDataPath}), kuboExePath (${kuboExePath})`, "kubo ipfs config file", path.join(ipfsDataPath, "config"));
-        log("If you would like to change kubo config, please edit the config file at", path.join(ipfsDataPath, "config"));
+    const kuboExePath = await getKuboExePath();
+    const kuboVersion = await getKuboVersion();
+    log(`Using Kubo version: ${kuboVersion}`);
+    log(`IpfsDataPath (${ipfsDataPath}), kuboExePath (${kuboExePath})`, "kubo ipfs config file", path.join(ipfsDataPath, "config"));
+    log("If you would like to change kubo config, please edit the config file at", path.join(ipfsDataPath, "config"));
 
-        const env = { IPFS_PATH: ipfsDataPath, DEBUG_COLORS: "1" };
+    const env = { IPFS_PATH: ipfsDataPath, DEBUG_COLORS: "1" };
 
-        let configJustInitialized = false;
-        try {
-            await _spawnAsync(log, kuboExePath, ["init"], { env, hideWindows: true });
-            configJustInitialized = true;
-        } catch (e) {
-            const error = <Error>e;
-            if (!error?.message?.includes("ipfs configuration file already exists!")) throw new Error("Failed to call ipfs init" + error);
-        }
-        if (configJustInitialized) {
-            await _spawnAsync(log, kuboExePath, ["config", "profile", "apply", `server`], {
-                env,
-                hideWindows: true
-            });
-            log("Called 'ipfs config profile apply server' successfully");
-            await mergeCliDefaultsIntoIpfsConfig(log, ipfsConfigPath, apiUrl, gatewayUrl);
-        } else {
-            log("IPFS config already exists; skipping config overrides to preserve user changes.");
-        }
+    let configJustInitialized = false;
+    try {
+        await _spawnAsync(log, kuboExePath, ["init"], { env, hideWindows: true });
+        configJustInitialized = true;
+    } catch (e) {
+        const error = <Error>e;
+        if (!error?.message?.includes("ipfs configuration file already exists!")) throw new Error("Failed to call ipfs init" + error);
+    }
+    if (configJustInitialized) {
+        await _spawnAsync(log, kuboExePath, ["config", "profile", "apply", `server`], {
+            env,
+            hideWindows: true
+        });
+        log("Called 'ipfs config profile apply server' successfully");
+        await mergeCliDefaultsIntoIpfsConfig(log, ipfsConfigPath, apiUrl, gatewayUrl);
+    } else {
+        log("IPFS config already exists; skipping config overrides to preserve user changes.");
+    }
 
-        try {
-            await _spawnAsync(log, kuboExePath, ["repo", "migrate"], { env, hideWindows: true });
-            log("Ensured IPFS repository is migrated to the latest supported version.");
-        } catch (migrationError) {
-            log.error("Failed to run IPFS repo migrations automatically", migrationError);
-            throw migrationError;
-        }
+    try {
+        await _spawnAsync(log, kuboExePath, ["repo", "migrate"], { env, hideWindows: true });
+        log("Ensured IPFS repository is migrated to the latest supported version.");
+    } catch (migrationError) {
+        log.error("Failed to run IPFS repo migrations automatically", migrationError);
+        throw migrationError;
+    }
 
-        try {
-            await ensureIpfsPortsAreAvailable(log, ipfsConfigPath, apiUrl, gatewayUrl);
-        } catch (error) {
-            reject(error instanceof Error ? error : new Error(String(error)));
-            return;
-        }
+    await ensureIpfsPortsAreAvailable(log, ipfsConfigPath, apiUrl, gatewayUrl);
 
+    // Spawn phase: the promise only wraps the event-driven wait for kubo's "Daemon is ready",
+    // so every settle path goes through resolve/reject.
+    return new Promise((resolve, reject) => {
         const daemonArgs = ["--enable-namesys-pubsub", "--migrate"];
 
         const kuboProcess: ChildProcessWithoutNullStreams = spawn(kuboExePath, ["daemon", ...daemonArgs], {

--- a/test/cli/daemon-kubo-restart-race.test.ts
+++ b/test/cli/daemon-kubo-restart-race.test.ts
@@ -14,7 +14,7 @@
 // The PKC_CLI_TEST_KEEPKUBOUP_PORTCHECK_DELAY_MS hook widens the guard->assignment window so
 // a watchdog tick deterministically lands inside it (same pattern as PKC_CLI_TEST_IPFS_READY_DELAY_MS).
 import { describe, it, expect, afterEach } from "vitest";
-import type { ChildProcessWithoutNullStreams } from "child_process";
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from "child_process";
 import { directory as randomDirectory } from "tempy";
 import dns from "node:dns";
 import path from "path";
@@ -37,6 +37,11 @@ const RACE_KUBO_API_URL = `http://localhost:50299/api/v0`;
 
 const SETTLE_KUBO_API_URL = new URL(`http://127.0.0.1:50399/api/v0`);
 const SETTLE_GATEWAY_URL = new URL(`http://127.0.0.1:6853`);
+
+const WEDGE_RPC_URL = `ws://localhost:9648`;
+const WEDGE_KUBO_URL = new URL(`http://0.0.0.0:50499/api/v0`);
+const WEDGE_GATEWAY_URL = new URL(`http://0.0.0.0:6953`);
+const WEDGE_KUBO_API_URL = `http://localhost:50499/api/v0`;
 
 const killProcessGroup = (pid: number, signal: NodeJS.Signals) => {
     if (process.platform !== "win32") {
@@ -125,6 +130,83 @@ describe("daemon kubo restart race (issue #70)", () => {
             } finally {
                 if (daemonProcess) await stopPkcDaemon(daemonProcess);
                 await ensureKuboNodeStopped(RACE_KUBO_API_URL);
+            }
+        }
+    );
+});
+
+describe("daemon shutdown with a wedged kubo startup (issue #70, PR #71 review)", () => {
+    it.skipIf(process.platform === "win32")(
+        "SIGTERM during a kubo start that never completes must not block shutdown unboundedly",
+        { timeout: 240000 },
+        async () => {
+            // Simulate a kubo that spawns and serves its API but whose startKuboNode promise
+            // never settles within any reasonable horizon (kubo wedged before "Daemon is ready"
+            // from the daemon's point of view): hold the ready acknowledgement for 10 minutes.
+            const dataPath = randomDirectory();
+            await preInitKuboWithEphemeralSwarm(path.join(dataPath, ".bitsocial-cli.ipfs"), WEDGE_KUBO_URL, WEDGE_GATEWAY_URL);
+
+            let daemonProcess: ChildProcess | undefined;
+            try {
+                await ensureKuboNodeStopped(WEDGE_KUBO_API_URL);
+                daemonProcess = spawn(
+                    "node",
+                    ["./bin/run", "daemon", "--logPath", randomDirectory(), "--pkcOptions.dataPath", dataPath, "--pkcRpcUrl", WEDGE_RPC_URL],
+                    {
+                        stdio: ["pipe", "pipe", "pipe"],
+                        env: {
+                            ...process.env,
+                            KUBO_RPC_URL: WEDGE_KUBO_URL.toString(),
+                            IPFS_GATEWAY_URL: WEDGE_GATEWAY_URL.toString(),
+                            PKC_CLI_TEST_IPFS_READY_DELAY_MS: "600000"
+                        }
+                    }
+                );
+                expect(typeof daemonProcess.pid).toBe("number");
+
+                // Wait until kubo is spawned and serving (daemon is now blocked inside the held
+                // startKuboNode promise; kuboProcess is tracked via onSpawn, pendingKuboStart pending)
+                const kuboUp = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${WEDGE_KUBO_API_URL}/version`, { method: "POST" });
+                            return res.ok;
+                        } catch {
+                            return false;
+                        }
+                    },
+                    60000,
+                    500
+                );
+                expect(kuboUp).toBe(true);
+
+                const killed = daemonProcess.kill();
+                expect(killed).toBe(true);
+
+                // Shutdown must reach the kill flow despite the pending start: the daemon should
+                // exit well before the exit hook's 120s hard cap force-kills the process.
+                const daemonExited = await waitForCondition(() => {
+                    return (daemonProcess?.exitCode ?? null) !== null || (daemonProcess?.signalCode ?? null) !== null;
+                }, 60000, 100);
+                expect(daemonExited).toBe(true);
+
+                const kuboStoppedAfterKill = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${WEDGE_KUBO_API_URL}/version`, { method: "POST" });
+                            return !res.ok;
+                        } catch {
+                            return true;
+                        }
+                    },
+                    10000,
+                    500
+                );
+                expect(kuboStoppedAfterKill).toBe(true);
+            } finally {
+                if (daemonProcess?.pid && daemonProcess.exitCode === null && daemonProcess.signalCode === null)
+                    killProcessGroup(daemonProcess.pid, "SIGKILL");
+                await ensureKuboNodeStopped(WEDGE_KUBO_API_URL);
             }
         }
     );

--- a/test/cli/daemon-kubo-restart-race.test.ts
+++ b/test/cli/daemon-kubo-restart-race.test.ts
@@ -212,6 +212,84 @@ describe("daemon shutdown with a wedged kubo startup (issue #70, PR #71 review)"
     );
 });
 
+describe("daemon shutdown with a late signal-exit registrant (issue #70)", () => {
+    const SIGEXIT_RPC_URL = `ws://localhost:9748`;
+    const SIGEXIT_KUBO_URL = `http://0.0.0.0:50599/api/v0`;
+    const SIGEXIT_GATEWAY_URL = `http://0.0.0.0:7053`;
+    const SIGEXIT_KUBO_API_URL = `http://localhost:50599/api/v0`;
+
+    it.skipIf(process.platform === "win32")(
+        "kubo is killed on SIGTERM even when a signal-exit handler registered after the exit hook",
+        { timeout: 120000 },
+        async () => {
+            // Reproduces the CI failure mechanism: a dependency (e.g. @pkcprotocol/proper-lock-file,
+            // or the signal-exit copies under ink/restore-cursor) registers a signal-exit handler
+            // after the daemon's asyncExitHook. exit-hook uses process.once, so on SIGTERM its
+            // listener disappears as soon as it is invoked; signal-exit then sees only its own
+            // family left and re-raises the signal, killing the daemon while the async kubo
+            // cleanup is still parked — the restarted kubo outlives the daemon.
+            let daemonProcess: ManagedChildProcess | undefined;
+            try {
+                await ensureKuboNodeStopped(SIGEXIT_KUBO_API_URL);
+                daemonProcess = await startPkcDaemon(
+                    ["--pkcOptions.dataPath", randomDirectory(), "--pkcRpcUrl", SIGEXIT_RPC_URL],
+                    {
+                        KUBO_RPC_URL: SIGEXIT_KUBO_URL,
+                        IPFS_GATEWAY_URL: SIGEXIT_GATEWAY_URL,
+                        PKC_CLI_TEST_SIMULATE_LATE_SIGNAL_EXIT: "1",
+                        // Hold the restarted kubo's start promise so SIGTERM lands mid-start,
+                        // like the CI failure (SIGTERM 0.4s after the restarted kubo's API came up)
+                        PKC_CLI_TEST_IPFS_READY_DELAY_MS: "5000"
+                    }
+                );
+                expect(typeof daemonProcess.pid).toBe("number");
+
+                const shutdownRes = await fetch(`${SIGEXIT_KUBO_API_URL}/shutdown`, { method: "POST" });
+                expect(shutdownRes.status).toBe(200);
+
+                const kuboRestarted = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${SIGEXIT_KUBO_API_URL}/bitswap/stat`, { method: "POST" });
+                            return res.ok;
+                        } catch {
+                            return false;
+                        }
+                    },
+                    30000,
+                    500
+                );
+                expect(kuboRestarted).toBe(true);
+
+                const killed = daemonProcess.kill();
+                expect(killed).toBe(true);
+
+                const daemonExited = await waitForCondition(() => {
+                    return (daemonProcess?.exitCode ?? null) !== null || (daemonProcess?.signalCode ?? null) !== null;
+                }, 30000, 100);
+                expect(daemonExited).toBe(true);
+
+                const kuboStoppedAfterKill = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${SIGEXIT_KUBO_API_URL}/bitswap/stat`, { method: "POST" });
+                            return !res.ok;
+                        } catch {
+                            return true;
+                        }
+                    },
+                    10000,
+                    500
+                );
+                expect(kuboStoppedAfterKill).toBe(true);
+            } finally {
+                if (daemonProcess) await stopPkcDaemon(daemonProcess);
+                await ensureKuboNodeStopped(SIGEXIT_KUBO_API_URL);
+            }
+        }
+    );
+});
+
 describe("startKuboNode settles on failure (issue #70)", () => {
     let firstKubo: ChildProcessWithoutNullStreams | undefined;
 

--- a/test/cli/daemon-kubo-restart-race.test.ts
+++ b/test/cli/daemon-kubo-restart-race.test.ts
@@ -1,0 +1,168 @@
+// Regression tests for issue #70: races in the daemon's kubo restart/cleanup machinery.
+//
+// Bug 1 (re-entrant keepKuboUp): the kubo exit handler and the 5s watchdog tick can both
+// pass keepKuboUp's re-entrancy guard, because the guard and the pendingKuboStart assignment
+// are separated by an await. The second entrant then acts on a stale port-check result.
+// Bug 2 (startKuboNode never settles): throws inside its async promise executor (e.g. when
+// `ipfs init` fails because a kubo daemon already runs on the repo) become unhandledRejections
+// and the returned promise never settles, wedging pendingKuboStart forever and hanging the
+// daemon's exit hook (which awaits it).
+// Bug 3 (failure path clobbers shared state): the catch around a failed start attempt clears
+// kuboProcess/pendingKuboStart unconditionally, orphaning another attempt's healthy kubo so
+// nothing kills it on daemon exit.
+//
+// The PKC_CLI_TEST_KEEPKUBOUP_PORTCHECK_DELAY_MS hook widens the guard->assignment window so
+// a watchdog tick deterministically lands inside it (same pattern as PKC_CLI_TEST_IPFS_READY_DELAY_MS).
+import { describe, it, expect, afterEach } from "vitest";
+import type { ChildProcessWithoutNullStreams } from "child_process";
+import { directory as randomDirectory } from "tempy";
+import dns from "node:dns";
+import path from "path";
+import {
+    type ManagedChildProcess,
+    stopPkcDaemon,
+    waitForCondition,
+    startPkcDaemon,
+    ensureKuboNodeStopped
+} from "../helpers/daemon-helpers.js";
+import { preInitKuboWithEphemeralSwarm } from "../helpers/kubo-helpers.js";
+import { startKuboNode } from "../../dist/ipfs/startIpfs.js";
+dns.setDefaultResultOrder("ipv4first"); // to be able to resolve localhost
+
+// --- Port allocations unique to this file (avoid conflicts with other test files and external processes) ---
+const RACE_RPC_URL = `ws://localhost:9548`;
+const RACE_KUBO_URL = `http://0.0.0.0:50299/api/v0`;
+const RACE_GATEWAY_URL = `http://0.0.0.0:6753`;
+const RACE_KUBO_API_URL = `http://localhost:50299/api/v0`;
+
+const SETTLE_KUBO_API_URL = new URL(`http://127.0.0.1:50399/api/v0`);
+const SETTLE_GATEWAY_URL = new URL(`http://127.0.0.1:6853`);
+
+const killProcessGroup = (pid: number, signal: NodeJS.Signals) => {
+    if (process.platform !== "win32") {
+        try {
+            process.kill(-pid, signal);
+        } catch {
+            /* best effort */
+        }
+    }
+    try {
+        process.kill(pid, signal);
+    } catch {
+        /* best effort */
+    }
+};
+
+describe("daemon kubo restart race (issue #70)", () => {
+    it.skipIf(process.platform === "win32")(
+        "concurrent keepKuboUp entries must not orphan kubo or hang shutdown",
+        { timeout: 120000 },
+        async () => {
+            let daemonProcess: ManagedChildProcess | undefined;
+            try {
+                await ensureKuboNodeStopped(RACE_KUBO_API_URL);
+                daemonProcess = await startPkcDaemon(
+                    ["--pkcOptions.dataPath", randomDirectory(), "--pkcRpcUrl", RACE_RPC_URL],
+                    {
+                        KUBO_RPC_URL: RACE_KUBO_URL,
+                        IPFS_GATEWAY_URL: RACE_GATEWAY_URL,
+                        // Hold every keepKuboUp entry for 7s between its guard and its pendingKuboStart
+                        // assignment — guarantees a 5s watchdog tick lands inside the window, so the
+                        // restart after the kubo shutdown below is entered twice concurrently.
+                        PKC_CLI_TEST_KEEPKUBOUP_PORTCHECK_DELAY_MS: "7000"
+                    }
+                );
+                expect(typeof daemonProcess.pid).toBe("number");
+
+                // Kill kubo out from under the daemon to trigger the restart cycle
+                const shutdownRes = await fetch(`${RACE_KUBO_API_URL}/shutdown`, { method: "POST" });
+                expect(shutdownRes.status).toBe(200);
+
+                // Restart is delayed ~7s by the hook; wait generously
+                const kuboRestarted = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${RACE_KUBO_API_URL}/bitswap/stat`, { method: "POST" });
+                            return res.ok;
+                        } catch {
+                            return false;
+                        }
+                    },
+                    40000,
+                    500
+                );
+                expect(kuboRestarted).toBe(true);
+
+                // Give the second (watchdog-tick) keepKuboUp entrant time to fail against the
+                // already-restarted kubo and corrupt the shared state (bugs 1+3)
+                await new Promise((resolve) => setTimeout(resolve, 10000));
+
+                const killed = daemonProcess.kill();
+                expect(killed).toBe(true);
+
+                // With the bug, the daemon either hangs in its exit hook (pendingKuboStart stuck
+                // on a never-settling start attempt, bug 2)...
+                const daemonExited = await waitForCondition(() => {
+                    return (daemonProcess?.exitCode ?? null) !== null || (daemonProcess?.signalCode ?? null) !== null;
+                }, 30000, 100);
+                expect(daemonExited).toBe(true);
+
+                // ...or exits without killing the restarted kubo because the failed second entrant
+                // cleared kuboProcess/pendingKuboStart (bug 3) — the orphaned kubo outlives the daemon.
+                const kuboStoppedAfterKill = await waitForCondition(
+                    async () => {
+                        try {
+                            const res = await fetch(`${RACE_KUBO_API_URL}/bitswap/stat`, { method: "POST" });
+                            return !res.ok;
+                        } catch {
+                            return true;
+                        }
+                    },
+                    10000,
+                    500
+                );
+                expect(kuboStoppedAfterKill).toBe(true);
+            } finally {
+                if (daemonProcess) await stopPkcDaemon(daemonProcess);
+                await ensureKuboNodeStopped(RACE_KUBO_API_URL);
+            }
+        }
+    );
+});
+
+describe("startKuboNode settles on failure (issue #70)", () => {
+    let firstKubo: ChildProcessWithoutNullStreams | undefined;
+
+    afterEach(async () => {
+        if (firstKubo?.pid) killProcessGroup(firstKubo.pid, "SIGKILL");
+        firstKubo = undefined;
+        await ensureKuboNodeStopped(SETTLE_KUBO_API_URL.toString().replace(/\/$/, ""));
+    });
+
+    it.skipIf(process.platform === "win32")(
+        "rejects (instead of never settling) when ipfs init fails because a daemon already runs on the repo",
+        { timeout: 90000 },
+        async () => {
+            const dataPath = randomDirectory();
+            // Pre-init the repo with an ephemeral swarm port so parallel test kubos don't collide on 4001
+            await preInitKuboWithEphemeralSwarm(path.join(dataPath, ".bitsocial-cli.ipfs"), SETTLE_KUBO_API_URL, SETTLE_GATEWAY_URL);
+
+            // First start: brings up a real kubo daemon that holds the repo lock
+            firstKubo = await startKuboNode(SETTLE_KUBO_API_URL, SETTLE_GATEWAY_URL, dataPath);
+            expect(typeof firstKubo.pid).toBe("number");
+
+            // Second start on the same repo: `ipfs init` fails with "ipfs daemon is running".
+            // The returned promise must settle (reject) — with the bug it never settles and the
+            // error escapes as an unhandledRejection instead.
+            const secondStart = startKuboNode(SETTLE_KUBO_API_URL, SETTLE_GATEWAY_URL, dataPath);
+            const outcome = await Promise.race([
+                secondStart.then(
+                    () => "resolved",
+                    () => "rejected"
+                ),
+                new Promise<string>((resolve) => setTimeout(() => resolve("never-settled"), 20000))
+            ]);
+            expect(outcome).toBe("rejected");
+        }
+    );
+});

--- a/test/cli/daemon.test.ts
+++ b/test/cli/daemon.test.ts
@@ -393,11 +393,13 @@ describe("bitsocial daemon kubo restart cleanup", async () => {
         const previousDelay = process.env["PKC_CLI_TEST_IPFS_READY_DELAY_MS"];
         process.env["PKC_CLI_TEST_IPFS_READY_DELAY_MS"] = "5000";
 
+        // Explicit logPath so the daemon's DEBUG log files can be dumped if the test fails (issue #70)
+        const cleanupLogDir = randomDirectory();
         let daemonProcess: ManagedChildProcess | undefined;
         try {
             await ensureKuboNodeStopped(cleanupKuboApiUrl);
             daemonProcess = await startPkcDaemon(
-                ["--pkcOptions.dataPath", randomDirectory(), "--pkcRpcUrl", cleanupRpcUrl],
+                ["--logPath", cleanupLogDir, "--pkcOptions.dataPath", randomDirectory(), "--pkcRpcUrl", cleanupRpcUrl],
                 { KUBO_RPC_URL: cleanupKuboUrl, IPFS_GATEWAY_URL: cleanupGatewayUrl }
             );
             expect(typeof daemonProcess.pid).toBe("number");
@@ -431,6 +433,21 @@ describe("bitsocial daemon kubo restart cleanup", async () => {
                     return true;
                 }
             }, 10000, 500);
+            if (!kuboStoppedAfterKill) {
+                // Diagnostics for the flaky-on-CI failure (issue #70): the daemon's DEBUG output is
+                // redirected to its log files (not stderr), so dump those — they show which kubo
+                // pids were spawned, restarted and killed. Without this the CI log only contains
+                // the bare assertion.
+                const tail = (text: string | undefined, lines: number) => (text ?? "").split("\n").slice(-lines).join("\n");
+                console.log(`[restart-cleanup diagnostics] kubo still responding on ${cleanupKuboApiUrl} after daemon exit`);
+                console.log(`[restart-cleanup diagnostics] daemon exitCode=${daemonProcess.exitCode} signalCode=${daemonProcess.signalCode}`);
+                console.log(`[restart-cleanup diagnostics] daemon stdout tail:\n${tail(daemonProcess.capturedStdout, 40)}`);
+                console.log(`[restart-cleanup diagnostics] daemon stderr tail:\n${tail(daemonProcess.capturedStderr, 60)}`);
+                for (const logFile of await fsPromise.readdir(cleanupLogDir).catch(() => [] as string[])) {
+                    const content = await fsPromise.readFile(path.join(cleanupLogDir, logFile), "utf-8").catch(() => "");
+                    console.log(`[restart-cleanup diagnostics] log file ${logFile} tail:\n${tail(content, 250)}`);
+                }
+            }
             expect(kuboStoppedAfterKill).toBe(true);
         } finally {
             if (daemonProcess) await stopPkcDaemon(daemonProcess);


### PR DESCRIPTION
Closes #70

## What

Fixes the cluster of races behind the flaky CI test `daemon.test.ts > stops kubo when daemon exits during a restart cycle` (kubo outliving the daemon, or the daemon hanging in its exit hook). Root-cause analysis, CI history, and the smoking-gun trace are in #70.

## Changes

**`src/cli/commands/daemon.ts`**
- `keepKuboUp` is now a **single-flight** wrapper around `keepKuboUpOnce` — the kubo exit handler and the watchdog tick share one attempt instead of racing past the re-entrancy guard (bug 1)
- state (incl. `mainProcessExited`) is **re-checked after the awaits** before committing to a spawn, so the daemon never spawns kubo mid-shutdown
- failure paths and `onKuboExit` only clear `kuboProcess`/`pendingKuboStart` **they own**, so a failed attempt can no longer orphan another attempt's healthy kubo (bug 3)
- defense in depth: every spawned kubo pid lives in `liveKuboPids` until its `exit`; both `killKuboProcess` and the synchronous emergency `process.on("exit")` handler SIGKILL anything left in the set
- `killKuboProcess` also awaits any in-flight `keepKuboUp` before deciding what to kill

**`src/ipfs/startIpfs.ts`**
- `startKuboNode`'s preparation phase (init / config / repo migrate / port checks) no longer runs inside an `async` promise executor — failures now **reject the returned promise** instead of escaping as unhandledRejections that left it unsettled forever (wedging `pendingKuboStart` and hanging shutdown, bug 2)

## Tests

New `test/cli/daemon-kubo-restart-race.test.ts` reproduces the bugs deterministically via the new `PKC_CLI_TEST_KEEPKUBOUP_PORTCHECK_DELAY_MS` hook (same pattern as `PKC_CLI_TEST_IPFS_READY_DELAY_MS`), which widens the guard→assignment window so a watchdog tick reliably lands inside it:

- **concurrent keepKuboUp entries must not orphan kubo or hang shutdown** — before: `expected false to be true` (hang/orphan); after: passes
- **rejects (instead of never settling) when ipfs init fails because a daemon already runs on the repo** — before: `expected 'never-settled' to be 'rejected'` + vitest-reported Unhandled Rejection; after: rejects in ~1s

Full suite: 31 files, 249 passed, 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced daemon/IPFS restart race conditions and improved single-attempt startup coordination.
  * Stronger shutdown/cleanup to prevent orphaned IPFS processes (extra kill safeguards).
  * Improved error propagation from initialization so startup failures surface reliably.

* **Tests**
  * Added regression suites covering restart races, wedged startups, and startup-settle failures.
  * Improved test determinism and failure diagnostics (timing control and richer logs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->