### PR TITLE
fix(logs): close race that dropped appends in -f follow mode

### DIFF
--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -187,16 +187,21 @@ export default class Logs extends Command {
         let currentLogFile = latestLogFile;
 
         const existingContent = await fsPromise.readFile(currentLogFile, "utf-8");
+        // Anchor the follow offset to exactly the bytes we just read, NOT a separate
+        // fsPromise.stat() taken afterwards. A later stat is racy: any append landing between
+        // this read and the stat is skipped (position jumps past it) yet was never in the dump
+        // above, so follow mode silently drops those lines. Under load that window widens — this
+        // was the cause of the intermittent CI failure where an appended line was never surfaced
+        // (issue #77). Byte length (not string length) because position indexes bytes in the file.
+        let position = Buffer.byteLength(existingContent, "utf-8");
+        let pendingBuffer = "";
+
         const entries = this._parseLogEntries(existingContent);
         const filtered = this._filterEntries(entries, since, until);
         const streamFiltered = streamFilter ? this._filterByStream(filtered, streamFilter) : filtered;
         const tailed = this._tailEntries(streamFiltered, flags.tail);
         const initialOutput = tailed.map((e) => e.lines.join("\n")).join("\n");
         if (initialOutput) process.stdout.write(initialOutput + "\n");
-
-        const stat = await fsPromise.stat(currentLogFile);
-        let position = stat.size;
-        let pendingBuffer = "";
 
         // Watch for new data by reading directly from `position`. We intentionally do
         // NOT gate on fsPromise.stat().size — on Windows + NTFS, stat() returns a stale


### PR DESCRIPTION
## Context
Follow-up to #78. That PR merged the test hardening + diagnostics, but the **actual root-cause fix was pushed to the branch after #78 had already merged**, so it never reached master. This PR carries just that fix.

## Root cause (proven, not guessed)
The diagnostics added in #78 fired on the windows CI job and I then **reproduced the failure locally** under CPU saturation. `bitsocial logs -f` set its starting byte offset from a *separate* `fsPromise.stat()` taken **after** the initial `readFile` + parse + stdout write:

```
const existingContent = await readFile(file)   // reads N bytes, prints them
...parse/filter/write to stdout...             // <- an append can land here
const stat = await stat(file)                  // size now N+M
let position = stat.size                         // = N+M, skips the M new bytes
```

Any append landing between the `readFile` and the `stat` is silently dropped: those bytes were never in the printed dump, and `position` jumps past them, so the 300ms poll loop never re-reads them. Under load the window between the two `await`s widens — which is why the `logs -f` test failed intermittently on **all three platforms**. The follow-trace showed `position==observedSize` (whole file incl. the append) from the first poll with `bytesThisCycle=0` forever.

This also affected real users: a log line appended during `logs -f` startup could be intermittently missed.

## Fix
Anchor `position` to `Buffer.byteLength(existingContent)` — the exact bytes just read — before any further awaits. Anything appended afterward is at offset >= position and is picked up by the poll. No separate `stat`, no race window.

## Verification
- **20/20 green** under 48-process CPU saturation that previously reproduced the drop within ~2 runs.
- Full `logs.test.ts` (29 tests) passes.

Refs #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the logs command's follow/tail mode where some log entries could be skipped during rapid file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->