### PR TITLE
chore(deps): upgrade kubo 0.41.0 → 0.42.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "env-paths": "2.2.1",
                 "exit-hook": "4.0.0",
                 "express": "4.19.2",
-                "kubo": "0.41.0",
+                "kubo": "0.42.0",
                 "p-limit": "7.3.0",
                 "strip-json-comments": "5.0.3",
                 "tcp-port-used": "1.0.2",
@@ -18615,9 +18615,9 @@
             }
         },
         "node_modules/kubo": {
-            "version": "0.41.0",
-            "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.41.0.tgz",
-            "integrity": "sha512-r6t8kZ9/mgvtjZz/DTVE7fw206rcTAw8KrpQBmpc83lOZLxEmKG4m2KsNLHVENNtrSs/jj8FOi+9v9DHLiHrww==",
+            "version": "0.42.0",
+            "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.42.0.tgz",
+            "integrity": "sha512-980G+BC9sLKJZIjaJ2hI6sWMkYP55Fo00BRcBaoIZ0uPUUuiHu7u69ZTSsWTyBA6MbkLPAWCgbCD9jh3GWN2yA==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "env-paths": "2.2.1",
         "exit-hook": "4.0.0",
         "express": "4.19.2",
-        "kubo": "0.41.0",
+        "kubo": "0.42.0",
         "p-limit": "7.3.0",
         "strip-json-comments": "5.0.3",
         "tcp-port-used": "1.0.2",


### PR DESCRIPTION
Upgrades the bundled `kubo` dependency from `0.41.0` to `0.42.0` (latest official release from the ipfs/npm-kubo GitHub Actions pipeline; maps to kubo binary v0.42.0).

Fixes #80.

## Changelog review vs. our usage
Reviewed the [v0.42.0 release notes](https://github.com/ipfs/kubo/releases/tag/v0.42.0) against how bitsocial-cli drives kubo in `src/ipfs/startIpfs.ts`: `ipfs init`, `ipfs config profile apply server`, `ipfs repo migrate`, `ipfs daemon --enable-namesys-pubsub --migrate`, plus config edits to `Addresses`, `AutoTLS.Enabled`, and `Gateway.PublicGateways`.

**No breaking changes affect us:**
- **`Provide.DHT.Interval=0` semantics change** — the only breaking change in 0.42.0; daemon now refuses startup if `Provide.DHT.Interval=0` is set without explicit `Provide.Enabled`. We never set `Provide.*` in our config merge and don't depend on the `server` profile touching it. Not applicable.
- **`--enable-namesys-pubsub` / `--migrate`** — still valid in 0.42.0, not deprecated or removed.
- **`ipfs repo migrate`** — still works; now more resilient (retries across gateways with HTTP timeouts).
- **`ipfs routing provide` deprecated** (→ `ipfs provide once`) — we don't use it.
- New optional settings (`Internal.ShutdownTimeout` default 12h, `Migration.DownloadSources`, `Provide.DHT.SendProviderRecordTimeout`) and new RPC subcommands don't affect existing usage.

Avoided npm `kubo@1.0.1` — hand-published by an individual rather than the official GitHub Actions pipeline; kubo binary releases follow `0.x.0`.

## Verification
- `npm run build && npm run build:test` ✅
- `npm run test:cli` ✅ — 259 passed, 1 skipped (32 files), including the daemon and kubo restart-race suites that drive the real kubo binary, confirmed `ipfs version 0.42.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubo dependency to version 0.42.0, bringing the latest improvements and fixes from the upstream library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->