### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js to 0.0.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.41",
+                "@pkcprotocol/pkc-js": "0.0.45",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5413,9 +5413,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.41",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.41.tgz",
-            "integrity": "sha512-XC8McKK230mcydB8m+5qBeeYYjtgQ04G4AtfZX8G7GzjNyOii+Cj09MYrwutTg8gCZq6B9jNWttakGQ17wnuhg==",
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.45.tgz",
+            "integrity": "sha512-XK+JiGEXzLL5N91cc+mxx3Wr8TS0lWSeAqUbAznqggw+zVihnj0LiWcn7hwCAsUlDsUeGqM86/sndCGDt8+jRA==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.41",
+        "@pkcprotocol/pkc-js": "0.0.45",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -119,7 +119,7 @@ async function publishCommentWithChallenge(opts: {
         comment.on("challenge", async (challengeMsg: any) => {
             try {
                 challengeText = challengeMsg.challenges?.[0]?.challenge;
-                await comment.publishChallengeAnswers([challengeAnswer]);
+                await comment.publishChallengeAnswers({ challengeAnswers: [challengeAnswer] });
             } catch (err) {
                 clearTimeout(timeout);
                 reject(err);

--- a/test/cli/mintpass-integration.test.ts
+++ b/test/cli/mintpass-integration.test.ts
@@ -86,7 +86,7 @@ async function publishCommentWithChallenge(opts: {
         comment.on("challenge", async (challengeMsg: any) => {
             try {
                 challengeText = challengeMsg.challenges?.[0]?.challenge;
-                await comment.publishChallengeAnswers([challengeAnswer]);
+                await comment.publishChallengeAnswers({ challengeAnswers: [challengeAnswer] });
             } catch (err) {
                 clearTimeout(timeout);
                 reject(err);


### PR DESCRIPTION
## Summary
Upgrades `@pkcprotocol/pkc-js` from 0.0.41 → 0.0.45 (exact pin).

## Breaking change handled
0.0.45 changes `Publication.publishChallengeAnswers` to take `{ challengeAnswers: string[] }` instead of a bare `string[]`. The `src/` code does not call this API, but two integration tests did — both updated to the new signature.

## Verification
- `npm run build && npm run build:test` — pass
- `npm run test:cli` — 261 passed, 1 skipped (33 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@pkcprotocol/pkc-js` dependency to version 0.0.45.

* **Tests**
  * Updated integration tests to align with new API contract patterns for challenge-answer submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->