### PR TITLE
perf(cli): enable V8 compile cache in bin/run (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ USAGE
   $ bitsocial community list --pkcRpcUrl <value> [-q]
 
 FLAGS
-  -q, --quiet              Only display community addresses
+  -q, --quiet              Only display community addresses (much faster: skips the per-community 'started' lookup)
       --pkcRpcUrl=<value>  (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION

--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+// Enable the V8 compile cache before any imports so the CLI's own dist/, oclif and all
+// deps get bytecode-cached across invocations. No-op on Node < 22.8, and on any failure
+// it reports via its return value rather than throwing. Cache dir defaults to
+// os.tmpdir()/node-compile-cache; override with NODE_COMPILE_CACHE, disable with
+// NODE_DISABLE_COMPILE_CACHE=1.
+const { enableCompileCache } = await import("node:module");
+enableCompileCache?.();
+
 // Save and strip DEBUG before any imports so the debug module
 // doesn't auto-enable stderr output. The daemon command will
 // re-enable namespaces programmatically and redirect to the log file.

--- a/src/cli/commands/community/list.ts
+++ b/src/cli/commands/community/list.ts
@@ -10,7 +10,10 @@ export default class List extends BaseCommand {
     static override examples = ["bitsocial community list -q", "bitsocial community list"];
 
     static override flags = {
-        quiet: Flags.boolean({ char: "q", summary: "Only display community addresses" })
+        quiet: Flags.boolean({
+            char: "q",
+            summary: "Only display community addresses (much faster: skips the per-community 'started' lookup)"
+        })
     };
 
     async run(): Promise<void> {

--- a/test/cli/compile-cache.test.ts
+++ b/test/cli/compile-cache.test.ts
@@ -1,0 +1,78 @@
+import { spawn } from "node:child_process";
+import { describe, it, expect } from "vitest";
+import { directory as randomDirectory } from "tempy";
+import * as nodeModule from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+
+// bin/run calls module.enableCompileCache() before importing anything, so the CLI's own
+// dist/, @oclif/core and the rest of the dependency closure get bytecode-cached across
+// invocations (issue #90). enableCompileCache exists from Node 22.8; skip below it.
+const compileCacheSupported = typeof (nodeModule as { enableCompileCache?: unknown }).enableCompileCache === "function";
+
+const runBitsocial = (
+    args: string[],
+    env: NodeJS.ProcessEnv,
+    timeoutMs = 30_000
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> => {
+    return new Promise((resolve, reject) => {
+        const proc = spawn("node", ["./bin/run", ...args], { stdio: ["pipe", "pipe", "pipe"], env });
+        let stdout = "";
+        let stderr = "";
+        proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+        proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+        const timer = setTimeout(() => {
+            proc.kill("SIGKILL");
+            reject(new Error(`Timed out after ${timeoutMs}ms\nstdout: ${stdout}\nstderr: ${stderr}`));
+        }, timeoutMs);
+        proc.on("close", (exitCode) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, exitCode });
+        });
+    });
+};
+
+describe.skipIf(!compileCacheSupported)("bin/run enables the V8 compile cache (issue #90)", () => {
+    it("populates the default compile-cache dir on a plain --version run", { timeout: 40_000 }, async () => {
+        const tmpDir = randomDirectory();
+        // enableCompileCache() with no dir and no NODE_COMPILE_CACHE writes to
+        // os.tmpdir()/node-compile-cache. Redirect os.tmpdir() to an isolated dir
+        // (TMPDIR on POSIX, TEMP/TMP on Windows) so the run can't touch the real cache.
+        const cacheDir = path.join(tmpDir, "node-compile-cache");
+
+        // Strip any inherited NODE_COMPILE_CACHE / disable flag so the ONLY thing that can
+        // populate cacheDir is bin/run's own enableCompileCache() call, not the env var.
+        const env: NodeJS.ProcessEnv = { ...process.env, TMPDIR: tmpDir, TMP: tmpDir, TEMP: tmpDir };
+        delete env.NODE_COMPILE_CACHE;
+        delete env.NODE_DISABLE_COMPILE_CACHE;
+
+        expect(fs.existsSync(cacheDir), "compile cache dir should not exist before the run").toBe(false);
+
+        const result = await runBitsocial(["--version"], env);
+        expect(result.exitCode, `stderr: ${result.stderr}\nstdout: ${result.stdout}`).toBe(0);
+        expect(result.stdout).toContain("bitsocial-cli");
+
+        expect(fs.existsSync(cacheDir), `expected compile cache to be created at ${cacheDir}`).toBe(true);
+        const entries = fs.readdirSync(cacheDir);
+        expect(entries.length, `compile cache dir was empty: ${cacheDir}`).toBeGreaterThan(0);
+    });
+
+    it("respects NODE_DISABLE_COMPILE_CACHE=1 (no cache written)", { timeout: 40_000 }, async () => {
+        const tmpDir = randomDirectory();
+        const cacheDir = path.join(tmpDir, "node-compile-cache");
+
+        const env: NodeJS.ProcessEnv = {
+            ...process.env,
+            TMPDIR: tmpDir,
+            TMP: tmpDir,
+            TEMP: tmpDir,
+            NODE_DISABLE_COMPILE_CACHE: "1"
+        };
+        delete env.NODE_COMPILE_CACHE;
+
+        const result = await runBitsocial(["--version"], env);
+        expect(result.exitCode, `stderr: ${result.stderr}\nstdout: ${result.stdout}`).toBe(0);
+        // With the cache disabled the dir is never created (CLI still works normally).
+        expect(fs.existsSync(cacheDir), `compile cache should be disabled, found ${cacheDir}`).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

- **`bin/run`** now calls `module.enableCompileCache()` before the dynamic `@oclif/core` import, so the CLI's own `dist/` graph + oclif + the rest of the dependency closure get bytecode-cached across invocations. Optional-chained (`enableCompileCache?.()`) so it's a no-op on Node < 22.8 and never throws (failures are reported via its return value). Honors `NODE_COMPILE_CACHE` and `NODE_DISABLE_COMPILE_CACHE=1`.
- **`community list` `-q` doc** — the flag summary (and generated README) now note that `-q` is much faster because it skips the per-community `started` lookup.

Implements #90. Documents part of #76 (the real fix for the `started`-column cost is tracked upstream in pkcprotocol/pkc-js#141).

## Why

Profiling `bitsocial community list` on a slow host (Node v22.22.2, pkc-js 0.0.47) decomposed as:

| Layer | Median |
| --- | --- |
| bare `node -e 0` | ~0.07s |
| import `@pkcprotocol/pkc-js` alone | ~1.73s (was ~9s — pkc-js now self-caches) |
| `bitsocial --version` (oclif boot) | ~0.51s |
| `community list -q` (floor) | ~3.1s |
| `community list` (full) | ~5.1s median, 15.6s spike |

pkc-js already enables the compile cache for its own graph, but everything the CLI loads around it (its own ~600 `dist/` files, oclif, other deps) was still compiled uncached on every run. This recovers ~0.5–1s of that per-command floor on second-and-later runs; the win is larger on real commands than on `--version` (which compiles less of the graph).

## Testing

- Full `npm run test:cli` green: **301 passed, 1 skipped, 0 failed** (39 files, incl. the kubo/daemon integration suite).
- New `test/cli/compile-cache.test.ts` spawns the built `bin/run --version` with an isolated `TMPDIR` (and `NODE_COMPILE_CACHE` stripped) and asserts the default cache dir is populated **from `bin/run` itself**, not from an inherited env var; a second case asserts `NODE_DISABLE_COMPILE_CACHE=1` writes nothing and the CLI still works. Skipped on Node < 22.8.
- Local before/after on `--version`: 0.55s → 0.46s with the cache warm.

## Drawbacks (low)

- A few MB of bytecode under `os.tmpdir()/node-compile-cache` (ephemeral; cleared on reboot / per container lifetime).
- A one-time extra write on the first run after each upgrade or tmp wipe; every later run is faster.
- Graceful: if tmp is full/read-only/`noexec` or Node < 22.8, it's a no-op — never throws. Entries are validated by source hash + Node/V8 version, so stale/corrupt entries are recompiled, not mis-executed.

## Notes

- The prod speedup lands once this ships and is reinstalled there (prod runs the published CLI via npm + systemd).
- The biggest lever for `community list` specifically is still the `started` column (#76) — deliberately documentation-only here; structural fix proposed in pkcprotocol/pkc-js#141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  - Enabled V8 compile cache to improve CLI startup performance.

* **Documentation**
  - Clarified that the `--quiet` flag provides faster performance by skipping per-community lookups.

* **Tests**
  - Added tests for compile cache functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->