### PR TITLE
fix(ipfs): replace deprecated --enable-namesys-pubsub flag with Ipns.UsePubsub config

### DIFF
--- a/src/ipfs/startIpfs.ts
+++ b/src/ipfs/startIpfs.ts
@@ -72,6 +72,19 @@ export async function mergeCliDefaultsIntoIpfsConfig(log: any, ipfsConfigPath: s
     log("Applied bitsocial CLI defaults to freshly initialized IPFS config.", ipfsConfigPath);
 }
 
+// Kubo deprecated the `--enable-namesys-pubsub` daemon flag in favor of the `Ipns.UsePubsub`
+// config option. We previously passed that flag on every daemon start, so to preserve behavior
+// we ensure `Ipns.UsePubsub: true` is set on every start — including pre-existing repos whose
+// config we otherwise leave untouched. Only the single key is written; all other user settings
+// are preserved, and the file is left alone if it is already enabled.
+export async function ensureIpnsPubsubEnabled(log: any, ipfsConfigPath: string) {
+    const config = JSON.parse((await fsPromises.readFile(ipfsConfigPath)).toString());
+    if (config?.Ipns?.UsePubsub === true) return;
+    config.Ipns = { ...(config.Ipns ?? {}), UsePubsub: true };
+    await fsPromises.writeFile(ipfsConfigPath, JSON.stringify(config, null, 4));
+    log("Enabled Ipns.UsePubsub in IPFS config (replaces deprecated --enable-namesys-pubsub flag).", ipfsConfigPath);
+}
+
 // use this custom function instead of spawnSync for better logging
 // also spawnSync might have been causing crash on start on windows
 
@@ -246,6 +259,9 @@ export async function startKuboNode(
         log("IPFS config already exists; skipping config overrides to preserve user changes.");
     }
 
+    // Replaces the deprecated `--enable-namesys-pubsub` daemon flag; must run for existing repos too.
+    await ensureIpnsPubsubEnabled(log, ipfsConfigPath);
+
     try {
         await _spawnAsync(log, kuboExePath, ["repo", "migrate"], { env, hideWindows: true });
         log("Ensured IPFS repository is migrated to the latest supported version.");
@@ -259,7 +275,7 @@ export async function startKuboNode(
     // Spawn phase: the promise only wraps the event-driven wait for kubo's "Daemon is ready",
     // so every settle path goes through resolve/reject.
     return new Promise((resolve, reject) => {
-        const daemonArgs = ["--enable-namesys-pubsub", "--migrate"];
+        const daemonArgs = ["--migrate"];
 
         const kuboProcess: ChildProcessWithoutNullStreams = spawn(kuboExePath, ["daemon", ...daemonArgs], {
             env,

--- a/test/kubo/mergeCliDefaultsIntoIpfsConfig.test.ts
+++ b/test/kubo/mergeCliDefaultsIntoIpfsConfig.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { file as tempFile } from "tempy";
 import * as fs from "fs/promises";
 import path from "path";
-import { mergeCliDefaultsIntoIpfsConfig } from "../../src/ipfs/startIpfs.js";
+import { mergeCliDefaultsIntoIpfsConfig, ensureIpnsPubsubEnabled } from "../../src/ipfs/startIpfs.js";
 
 const noopLog = () => {
     /* no-op for tests */
@@ -92,5 +92,38 @@ describe("mergeCliDefaultsIntoIpfsConfig", () => {
 
         expect(mergedConfig.Gateway.PublicGateways["custom.host"]).toMatchObject({ UseSubdomains: false });
         expect(mergedConfig.Gateway.PublicGateways["127.0.0.1"]).toMatchObject({ UseSubdomains: false });
+    });
+});
+
+describe("ensureIpnsPubsubEnabled", () => {
+    it("sets Ipns.UsePubsub on a config that has no Ipns section", async () => {
+        const configPath = await writeConfigToTempFile({ Addresses: { Gateway: "/ip4/0.0.0.0/tcp/8080" } });
+
+        await ensureIpnsPubsubEnabled(noopLog, configPath);
+
+        const updated = JSON.parse(await fs.readFile(configPath, "utf-8"));
+        expect(updated.Ipns.UsePubsub).toBe(true);
+        // unrelated config is preserved
+        expect(updated.Addresses.Gateway).toBe("/ip4/0.0.0.0/tcp/8080");
+    });
+
+    it("preserves existing Ipns settings while enabling UsePubsub", async () => {
+        const configPath = await writeConfigToTempFile({ Ipns: { RepublishPeriod: "1h", UsePubsub: false } });
+
+        await ensureIpnsPubsubEnabled(noopLog, configPath);
+
+        const updated = JSON.parse(await fs.readFile(configPath, "utf-8"));
+        expect(updated.Ipns.UsePubsub).toBe(true);
+        expect(updated.Ipns.RepublishPeriod).toBe("1h");
+    });
+
+    it("is a no-op (no rewrite) when already enabled", async () => {
+        const configPath = await writeConfigToTempFile({ Ipns: { UsePubsub: true } });
+        const before = await fs.readFile(configPath, "utf-8");
+
+        await ensureIpnsPubsubEnabled(noopLog, configPath);
+
+        const after = await fs.readFile(configPath, "utf-8");
+        expect(after).toBe(before);
     });
 });


### PR DESCRIPTION
## Problem

Starting the kubo daemon logs a deprecation warning:

```
ERROR cmd/ipfs kubo/daemon.go:431 The --enable-namesys-pubsub flag is deprecated. Use Ipns.UsePubsub config option instead.
```

`src/ipfs/startIpfs.ts` passed `--enable-namesys-pubsub` to `ipfs daemon` on every start.

## Fix

- Removed `--enable-namesys-pubsub` from the daemon args (now just `["--migrate"]`).
- Added `ensureIpnsPubsubEnabled()`, which sets `Ipns.UsePubsub: true` in the kubo config, preserving all other settings and skipping the write if already enabled.
- Called it on **every** daemon start — not only fresh init. The old flag was passed on every start, while `mergeCliDefaultsIntoIpfsConfig` only runs for freshly-initialized repos, so existing nodes would otherwise silently lose IPNS-over-pubsub.

`Ipns.UsePubsub: true` is the documented equivalent of the old flag, and enabling it also enables the pubsub subsystem — so behavior is preserved with no separate `Pubsub.Enabled` needed.

## Tests

Added 3 cases for `ensureIpnsPubsubEnabled` (no `Ipns` section, preserve existing `Ipns` settings, no-op when already enabled). Build (`npm run build && npm run build:test`) and the kubo config tests pass (6/6).

Fixes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - IPFS startup now enables IPNS pubsub through configuration automatically, helping name publishing and resolution work more reliably.
  - Startup no longer relies on a deprecated daemon flag, reducing setup issues.
  - Existing IPFS settings are preserved when this update is applied, and no unnecessary config rewrite occurs when the setting is already enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->