### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js 0.0.62 -> 0.0.69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.62",
+                "@pkcprotocol/pkc-js": "0.0.69",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5850,9 +5850,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.62.tgz",
-            "integrity": "sha512-TNv+aDR2xy+kggwQjZYR3XMNxqhB+fWGbFQhDGLncFKfjGW169yGMziRoau4kPBPcQmCh/yZ5YUvVdYbY+jZSA==",
+            "version": "0.0.69",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.69.tgz",
+            "integrity": "sha512-L00qNu2BKsq8CEYP2tq5lHu4OKLGGovFNe8w68DtluHHf9/tJSTGsZkf+v3ntfdqcT/8WykTssQBsvdidyUpvg==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",
@@ -5900,7 +5900,7 @@
                 "p-timeout": "7.0.1",
                 "probe-image-size": "7.2.3",
                 "quick-lru": "5.1.1",
-                "remeda": "1.57.0",
+                "remeda": "2.39.0",
                 "retry": "0.13.1",
                 "rpc-websockets": "9.3.8",
                 "safe-stable-stringify": "2.4.3",
@@ -24155,10 +24155,16 @@
             }
         },
         "node_modules/remeda": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.57.0.tgz",
-            "integrity": "sha512-guUqXntj7WtPuT1DLmfNCeyMZ2pE5m4ffJnWkOsbVQSvPsGIhNcKeFV94LTxqggOWwaIubUd4FZKTlGIOg2wDw==",
-            "license": "MIT"
+            "version": "2.39.0",
+            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.39.0.tgz",
+            "integrity": "sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/remeda"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.62",
+        "@pkcprotocol/pkc-js": "0.0.69",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",

--- a/src/cli/commands/community/edit.ts
+++ b/src/cli/commands/community/edit.ts
@@ -114,7 +114,7 @@ For modifying complex settings like challenges, consider using a web UI instead:
         try {
             const community = await pkc.createCommunity({ address: args.address });
 
-            const mergedState = remeda.pick(community, remeda.keys.strict(editOptions) as (keyof typeof community)[]);
+            const mergedState = remeda.pick(community, remeda.keys(editOptions) as (keyof typeof community)[]);
             // JSON file edits use RFC 7396 JSON Merge Patch semantics (arrays replace, objects merge).
             // CLI flag edits use concat semantics (arrays extend with new values).
             const finalMergedState = mergeDeep(mergedState, editOptions, flags.jsonFile ? "replace" : "concat");


### PR DESCRIPTION
Upgrades @pkcprotocol/pkc-js from 0.0.62 to 0.0.69 (issue #114).

## Changes
- `@pkcprotocol/pkc-js` 0.0.62 -> 0.0.69 (exact version).
- `src/cli/commands/community/edit.ts`: the upgrade bumps pkc-js's remeda dependency 1.57.0 -> 2.39.0, and remeda v2 removed `keys.strict()` (`keys()` is strict by default). Adapted the one affected call site; all other remeda usage (`omit`, `pick`, `isPlainObject`) is unchanged in v2.

## Verification
- `npm run build && npm run build:test` passes.
- `npm run test:cli`: 310 passed, 1 skipped (40 test files), no failures.

Note: this repo imports `remeda` directly in several files but does not declare it in `package.json` — it resolves via hoisting from pkc-js. Worth declaring it as a direct dependency in a follow-up to avoid future silent major bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community editing so updates correctly preserve and apply available community settings.
  * Updated the underlying PKC integration to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->