### PR TITLE
chore(deps): upgrade 5chan web UI v0.9.7 -> v0.9.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,8 +144,8 @@
             "sha256OfHtmlZip": "14653b19e88868fda6fef26601f477947e44251cc52bd95d7d6fec158ae67b6f"
         },
         {
-            "url": "https://github.com/bitsocialnet/5chan/releases/tag/v0.9.7",
-            "sha256OfHtmlZip": "878f7291b309d2845c5f616f02b802830d0c8764c701f524322d4ff56024269f"
+            "url": "https://github.com/bitsocialnet/5chan/releases/tag/v0.9.17",
+            "sha256OfHtmlZip": "d7a8ebdd7a437568b828909093b7a881de6b091f6740ef81086427efb1752284"
         }
     ]
 }


### PR DESCRIPTION
Ran `npm run update-webuis`. Only 5chan had a new release; seedit (v0.5.10) and plebones (v0.1.27) are already at latest.

## Changes

- `bitsocialnet/5chan` v0.9.7 -> v0.9.17, with the new `sha256OfHtmlZip` for the release's HTML zip.

## Verification

- `npm run build && npm run build:test` — pass
- `npm run test:cli` — 319 passed, 1 skipped (41 files)
- `dist/webuis/` re-downloaded from scratch and now contains `5chan-0.9.17-html`
- The 5chan-specific `daemon.test.ts` case (`5chan webui does not contain the root hash redirect script`) still passes, so the index.html hash-redirect stripping in the postinstall step is still compatible with the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled 5chan web UI to release v0.9.17.
  * Improved release integrity verification with the latest archive checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->